### PR TITLE
fix(eslint-markdown)!: move `@eslint/markdown` to `peerDependencies` to fix compat issue with `@eslint/markdown` v8

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,6 +37,19 @@ jobs:
           - 10.0.0-rc.0
           - 9.x
           - 9.31.0
+        include:
+          - runner-image: ubuntu-latest
+            node-version: lts/*
+            eslint-version: 9.x
+            eslint-markdown-version: 7.0.0
+          - runner-image: ubuntu-latest
+            node-version: lts/*
+            eslint-version: 9.x
+            eslint-markdown-version: 7.x
+          - runner-image: ubuntu-latest
+            node-version: lts/*
+            eslint-version: 9.x
+            eslint-markdown-version: 8.x
 
     runs-on: ${{ matrix.runner-image }}
 
@@ -55,6 +68,9 @@ jobs:
 
       - name: Install ESLint
         run: npm install --no-audit --no-fund -D eslint@${{ matrix.eslint-version }} -w packages/eslint-markdown
+
+      - name: Install ESLint Markdown
+        run: npm install --no-audit --no-fund @eslint/markdown@${{ matrix.eslint-markdown-version }} -w packages/eslint-markdown
 
       - name: Build
         run: npm run build --if-present


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow in `.github/workflows/test.yml` to improve the testing matrix for ESLint and its Markdown plugin. The main changes add explicit combinations of ESLint and `@eslint/markdown` versions to the test matrix and ensure both dependencies are installed for each job.

### Test matrix improvements

* Expanded the test matrix to explicitly include combinations of `eslint-version` (`9.x`) and various `eslint-markdown-version` values (`7.0.0`, `7.x`, `8.x`) with the `node-version` set to `lts/*`. This ensures compatibility is tested across multiple plugin versions.

### Dependency installation

* Added a step to install `@eslint/markdown` at the specified version for each matrix job, ensuring that the correct plugin version is present during tests.