### PR TITLE
chore(website): remove unplugin dependency from Codecov Vite plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10031,7 +10031,6 @@
         "@shikijs/vitepress-twoslash": "^3.20.0",
         "eslint-markdown": "^0.13.0",
         "twoslash-eslint": "^0.3.4",
-        "unplugin": "^1.16.1",
         "vitepress": "2.0.0-alpha.17",
         "vitepress-plugin-group-icons": "^1.7.6"
       }

--- a/website/.vitepress/plugin.js
+++ b/website/.vitepress/plugin.js
@@ -43,7 +43,6 @@ import {
   Output,
   telemetryPlugin,
 } from '@codecov/bundler-plugin-core';
-import { createVitePlugin } from 'unplugin';
 
 // --------------------------------------------------------------------------------
 // Helper
@@ -66,121 +65,119 @@ const viteBundleAnalysisPlugin = ({ output, pluginName, pluginVersion }) => ({
   writeBundle: async () => {
     await output.write();
   },
-  vite: {
-    async generateBundle(options, bundle) {
-      if (!output.bundleName || output.bundleName === '') {
-        red('Bundle name is not present or empty. Skipping upload.');
-        return;
-      }
-      output.setBundleName(output.originalBundleName);
-      if (options.name && options.name !== '') {
-        output.setBundleName(`${output.bundleName}-${options.name}`);
-      }
-      const format = options.format === 'es' ? 'esm' : options.format;
-      output.setBundleName(`${output.bundleName}-${format}`);
-      const cwd = process.cwd();
-      const assets = [];
-      const chunks = [];
-      const moduleByFileName = /* @__PURE__ */ new Map();
-      const items = Object.values(bundle);
-      const customOptions = {
-        moduleOriginalSize: false,
-        ...options,
-      };
-      let assetFormatString = '';
-      if (typeof customOptions.assetFileNames === 'string') {
-        assetFormatString = customOptions.assetFileNames;
-      }
-      let chunkFormatString = '';
-      if (typeof customOptions.chunkFileNames === 'string') {
-        chunkFormatString = customOptions.chunkFileNames;
-      }
-      let counter = 0;
-      await Promise.all(
-        items.map(async item => {
-          if (item?.type === 'asset') {
-            const fileName = item?.fileName ?? '';
-            if (path.extname(fileName) === '.map') {
-              return;
-            }
-            const asset = await createRollupAsset({
-              fileName,
-              source: item.source,
-              formatString: assetFormatString,
-              metaFramework: output.metaFramework,
-            });
-            assets.push(asset);
-          } else if (item?.type === 'chunk') {
-            const fileName = item?.fileName ?? '';
-            if (path.extname(fileName) === '.map') {
-              return;
-            }
-            const asset = await createRollupAsset({
-              fileName,
-              source: item.code,
-              formatString: chunkFormatString,
-              metaFramework: output.metaFramework,
-            });
-            assets.push(asset);
-            const chunkId = item?.name ?? '';
-            const uniqueId = `${counter}-${chunkId}`;
-            chunks.push({
-              id: chunkId,
-              uniqueId,
-              entry: item?.isEntry,
-              initial: item?.isDynamicEntry,
-              files: [fileName],
-              names: [item?.name],
-              dynamicImports: item?.dynamicImports ?? [],
-            });
-            const moduleEntries = Object.entries(item?.modules ?? {});
-            for (const [modulePath, moduleInfo] of moduleEntries) {
-              const normalizedModulePath = modulePath.replace('\0', '');
-              const relativeModulePath = path.relative(cwd, normalizedModulePath);
-              const relativeModulePathWithPrefix = relativeModulePath.match(/^\.\./)
-                ? relativeModulePath
-                : `.${path.sep}${relativeModulePath}`;
-              const moduleEntry = moduleByFileName.get(relativeModulePathWithPrefix);
-              if (moduleEntry) {
-                moduleEntry.chunkUniqueIds.push(uniqueId);
-              } else {
-                const size = customOptions.moduleOriginalSize
-                  ? moduleInfo.originalLength
-                  : moduleInfo.renderedLength;
-                const module = {
-                  name: relativeModulePathWithPrefix,
-                  size,
-                  chunkUniqueIds: [uniqueId],
-                };
-                moduleByFileName.set(relativeModulePathWithPrefix, module);
-              }
-            }
-            counter += 1;
+  async generateBundle(options, bundle) {
+    if (!output.bundleName || output.bundleName === '') {
+      red('Bundle name is not present or empty. Skipping upload.');
+      return;
+    }
+    output.setBundleName(output.originalBundleName);
+    if (options.name && options.name !== '') {
+      output.setBundleName(`${output.bundleName}-${options.name}`);
+    }
+    const format = options.format === 'es' ? 'esm' : options.format;
+    output.setBundleName(`${output.bundleName}-${format}`);
+    const cwd = process.cwd();
+    const assets = [];
+    const chunks = [];
+    const moduleByFileName = /* @__PURE__ */ new Map();
+    const items = Object.values(bundle);
+    const customOptions = {
+      moduleOriginalSize: false,
+      ...options,
+    };
+    let assetFormatString = '';
+    if (typeof customOptions.assetFileNames === 'string') {
+      assetFormatString = customOptions.assetFileNames;
+    }
+    let chunkFormatString = '';
+    if (typeof customOptions.chunkFileNames === 'string') {
+      chunkFormatString = customOptions.chunkFileNames;
+    }
+    let counter = 0;
+    await Promise.all(
+      items.map(async item => {
+        if (item?.type === 'asset') {
+          const fileName = item?.fileName ?? '';
+          if (path.extname(fileName) === '.map') {
+            return;
           }
-        }),
-      );
-      const modules = Array.from(moduleByFileName.values());
-      output.bundler = {
-        name: 'rollup',
-        version: this.meta.rollupVersion,
-      };
-      output.assets = assets;
-      output.chunks = chunks;
-      output.modules = modules;
-      output.outputPath = options.dir ?? '';
-      if (output.dryRun) {
-        this.emitFile({
-          type: 'asset',
-          fileName: `${output.bundleName}-stats.json`,
-          source: output.bundleStatsToJson(),
-        });
-      }
-    },
+          const asset = await createRollupAsset({
+            fileName,
+            source: item.source,
+            formatString: assetFormatString,
+            metaFramework: output.metaFramework,
+          });
+          assets.push(asset);
+        } else if (item?.type === 'chunk') {
+          const fileName = item?.fileName ?? '';
+          if (path.extname(fileName) === '.map') {
+            return;
+          }
+          const asset = await createRollupAsset({
+            fileName,
+            source: item.code,
+            formatString: chunkFormatString,
+            metaFramework: output.metaFramework,
+          });
+          assets.push(asset);
+          const chunkId = item?.name ?? '';
+          const uniqueId = `${counter}-${chunkId}`;
+          chunks.push({
+            id: chunkId,
+            uniqueId,
+            entry: item?.isEntry,
+            initial: item?.isDynamicEntry,
+            files: [fileName],
+            names: [item?.name],
+            dynamicImports: item?.dynamicImports ?? [],
+          });
+          const moduleEntries = Object.entries(item?.modules ?? {});
+          for (const [modulePath, moduleInfo] of moduleEntries) {
+            const normalizedModulePath = modulePath.replace('\0', '');
+            const relativeModulePath = path.relative(cwd, normalizedModulePath);
+            const relativeModulePathWithPrefix = relativeModulePath.match(/^\.\./)
+              ? relativeModulePath
+              : `.${path.sep}${relativeModulePath}`;
+            const moduleEntry = moduleByFileName.get(relativeModulePathWithPrefix);
+            if (moduleEntry) {
+              moduleEntry.chunkUniqueIds.push(uniqueId);
+            } else {
+              const size = customOptions.moduleOriginalSize
+                ? moduleInfo.originalLength
+                : moduleInfo.renderedLength;
+              const module = {
+                name: relativeModulePathWithPrefix,
+                size,
+                chunkUniqueIds: [uniqueId],
+              };
+              moduleByFileName.set(relativeModulePathWithPrefix, module);
+            }
+          }
+          counter += 1;
+        }
+      }),
+    );
+    const modules = Array.from(moduleByFileName.values());
+    output.bundler = {
+      name: 'rollup',
+      version: this.meta.rollupVersion,
+    };
+    output.assets = assets;
+    output.chunks = chunks;
+    output.modules = modules;
+    output.outputPath = options.dir ?? '';
+    if (output.dryRun) {
+      this.emitFile({
+        type: 'asset',
+        fileName: `${output.bundleName}-stats.json`,
+        source: output.bundleStatsToJson(),
+      });
+    }
   },
 });
 
-const codecovVitePlugin = createVitePlugin((userOptions, unpluginMetaContext) => {
-  if (checkNodeVersion(unpluginMetaContext)) {
+const codecovVitePlugin = userOptions => {
+  if (checkNodeVersion({ framework: 'vite' })) {
     return [];
   }
   const normalizedOptions = normalizeOptions(userOptions);
@@ -199,13 +196,9 @@ const codecovVitePlugin = createVitePlugin((userOptions, unpluginMetaContext) =>
     pluginName: PLUGIN_NAME,
     pluginVersion: PLUGIN_VERSION,
     options,
-    bundler: unpluginMetaContext.framework,
+    bundler: 'vite',
   });
-  const output = new Output(
-    options,
-    { metaFramework: unpluginMetaContext.framework },
-    sentryConfig,
-  );
+  const output = new Output(options, { metaFramework: 'vite' }, sentryConfig);
   if (options.enableBundleAnalysis) {
     plugins.push(
       telemetryPlugin({
@@ -221,7 +214,7 @@ const codecovVitePlugin = createVitePlugin((userOptions, unpluginMetaContext) =>
     );
   }
   return plugins;
-});
+};
 
 // --------------------------------------------------------------------------------
 // Export

--- a/website/package.json
+++ b/website/package.json
@@ -13,7 +13,6 @@
     "@shikijs/vitepress-twoslash": "^3.20.0",
     "eslint-markdown": "^0.13.0",
     "twoslash-eslint": "^0.3.4",
-    "unplugin": "^1.16.1",
     "vitepress": "2.0.0-alpha.17",
     "vitepress-plugin-group-icons": "^1.7.6"
   }


### PR DESCRIPTION
This pull request refactors the custom Vite plugin implementation in `website/.vitepress/plugin.js` to remove the dependency on the `unplugin` package and simplify the plugin structure. The changes streamline the code by eliminating unnecessary abstractions and updating references to the Vite framework directly.

**Plugin refactoring and dependency removal:**

* Removed the import and usage of `createVitePlugin` from the `unplugin` package, and updated the custom plugin to be a plain function instead of using `unplugin` abstractions. (`website/.vitepress/plugin.js`) [[1]](diffhunk://#diff-0ca877b569746e59146f81faf2f77e78ba88ce221b31d4c4a37b247ec3ad2e8bL46) [[2]](diffhunk://#diff-0ca877b569746e59146f81faf2f77e78ba88ce221b31d4c4a37b247ec3ad2e8bL179-R180) [[3]](diffhunk://#diff-0ca877b569746e59146f81faf2f77e78ba88ce221b31d4c4a37b247ec3ad2e8bL224-R217)
* Updated all references from `unpluginMetaContext.framework` to the string `'vite'` to reflect the removal of `unplugin` and ensure correct framework identification. (`website/.vitepress/plugin.js`)
* Removed `unplugin` from the project dependencies in `website/package.json`.

**Minor code cleanup:**

* Removed the unnecessary `vite` property wrapper from the `viteBundleAnalysisPlugin` object, flattening the plugin structure. (`website/.vitepress/plugin.js`)