### PR TITLE
chore(eslint-markdown): fix a typo in variable name

### DIFF
--- a/packages/eslint-markdown/src/rules/allow-image-url.ts
+++ b/packages/eslint-markdown/src/rules/allow-image-url.ts
@@ -106,16 +106,16 @@ export default {
     const { sourceCode } = context;
     const [
       {
-        allowUrls: allowUrlsOptions,
-        disallowUrls: disallowUrlsOptions,
-        allowDefinitions: allowDefinitionsOptions,
+        allowUrls: allowUrlsOption,
+        disallowUrls: disallowUrlsOption,
+        allowDefinitions: allowDefinitionsOption,
       },
     ] = context.options;
 
-    const allowUrls = allowUrlsOptions.map(normalizeRegexPattern);
-    const disallowUrls = disallowUrlsOptions.map(normalizeRegexPattern);
+    const allowUrls = allowUrlsOption.map(normalizeRegexPattern);
+    const disallowUrls = disallowUrlsOption.map(normalizeRegexPattern);
     const allowDefinitions = new Set(
-      allowDefinitionsOptions.map(identifier =>
+      allowDefinitionsOption.map(identifier =>
         normalizeIdentifier(identifier).toLowerCase(),
       ),
     );


### PR DESCRIPTION
This pull request makes a minor refactor to the `allow-image-url` ESLint rule to improve variable naming consistency. The main change is renaming option variables from plural to singular forms for clarity.

- Refactored option variable names from plural (`allowUrlsOptions`, `disallowUrlsOptions`, `allowDefinitionsOptions`) to singular (`allowUrlsOption`, `disallowUrlsOption`, `allowDefinitionsOption`) in `allow-image-url.ts` for improved readability and consistency.