### PR TITLE
chore(release): bump package versions from `v0.13.0` to `v0.14.0` (`minor`)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "npm-eslint-markdown",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "npm-eslint-markdown",
-      "version": "0.13.0",
+      "version": "0.14.0",
       "workspaces": [
         "packages/*",
         "website"
@@ -9989,7 +9989,7 @@
       }
     },
     "packages/eslint-markdown": {
-      "version": "0.13.0",
+      "version": "0.14.0",
       "license": "MIT",
       "dependencies": {
         "@eslint/markdown": "^7.5.1",
@@ -10029,7 +10029,7 @@
         "@codecov/bundler-plugin-core": "^2.0.1",
         "@shikijs/transformers": "^3.20.0",
         "@shikijs/vitepress-twoslash": "^3.20.0",
-        "eslint-markdown": "^0.13.0",
+        "eslint-markdown": "^0.14.0",
         "twoslash-eslint": "^0.3.4",
         "vitepress": "2.0.0-alpha.17",
         "vitepress-plugin-group-icons": "^1.7.6"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "npm-eslint-markdown",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "type": "module",
   "packageManager": "npm@10.9.2",
   "engines": {

--- a/packages/eslint-markdown/package.json
+++ b/packages/eslint-markdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-markdown",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "type": "module",
   "sideEffects": false,
   "description": "Lint your Markdown with ESLint. Additional rules for use with `@eslint/markdown`.🛠️",

--- a/website/package.json
+++ b/website/package.json
@@ -11,7 +11,7 @@
     "@codecov/bundler-plugin-core": "^2.0.1",
     "@shikijs/transformers": "^3.20.0",
     "@shikijs/vitepress-twoslash": "^3.20.0",
-    "eslint-markdown": "^0.13.0",
+    "eslint-markdown": "^0.14.0",
     "twoslash-eslint": "^0.3.4",
     "vitepress": "2.0.0-alpha.17",
     "vitepress-plugin-group-icons": "^1.7.6"


### PR DESCRIPTION
## Release Information: `v0.14.0`

New release of `lumirlumir/npm-eslint-markdown` has arrived! :tada:

This PR bumps the package versions from `v0.13.0` to `v0.14.0` (`minor`).

See [Actions](https://github.com/lumirlumir/npm-eslint-markdown/actions/runs/32272662914) for more details.

| Info        | Value                      |
| ----------- | -------------------------- |
| Repository  | `lumirlumir/npm-eslint-markdown` |
| SEMVER      | `minor`     |
| Pre ID      | `canary`      |
| Short SHA   | d6a5479       |
| Old Version | `v0.13.0`  |
| New Version | `v0.14.0`  |

<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
### :sparkles: Features
* feat(eslint-markdown): support string patterns in `allow-*` rules and stricter option schema by @tooth-is-silver in https://github.com/lumirlumir/npm-eslint-markdown/pull/655
### :toolbox: Chores
* chore(*): configure linting for local type tests and update `package.json` by @lumirlumir in https://github.com/lumirlumir/npm-eslint-markdown/pull/645
* chore(eslint-markdown): remove dummy rule `no-bold-paragraph` by @lumirlumir in https://github.com/lumirlumir/npm-eslint-markdown/pull/649
* chore(website): remove unplugin dependency from Codecov Vite plugin by @lumirlumir in https://github.com/lumirlumir/npm-eslint-markdown/pull/650
* chore(*): enforce import ordering in rule files by @tooth-is-silver in https://github.com/lumirlumir/npm-eslint-markdown/pull/653
* chore(eslint-markdown): fix a typo in variable name by @lumirlumir in https://github.com/lumirlumir/npm-eslint-markdown/pull/656
### :arrow_up: Dependency Updates
* chore(deps-dev): bump undici from 6.27.0 to 6.28.0 by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-markdown/pull/644
* chore(deps-dev): bump postcss from 8.5.16 to 8.5.25 by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-markdown/pull/643
* chore(deps-dev): bump brace-expansion from 1.1.15 to 1.1.18 by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-markdown/pull/642


**Full Changelog**: https://github.com/lumirlumir/npm-eslint-markdown/compare/v0.13.0...v0.14.0