### PR TITLE
chore(website): add static fallbacks for config inspector routes

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "website"
   ],
   "scripts": {
-    "prepare": "husky",
+    "prepare": "husky && node ./scripts/patch.js",
     "release:publish": "node -e \"require('child_process').execSync('npm publish -w packages ' + (require('./package.json').version.includes('-') ? '--tag next' : ''), { stdio: 'inherit' })\"",
     "release:version": "node ./scripts/version.js",
     "coverage": "vitest run --coverage",

--- a/scripts/patch.js
+++ b/scripts/patch.js
@@ -1,0 +1,28 @@
+/**
+ * @fileoverview Script to patch packages.
+ */
+
+// --------------------------------------------------------------------------------
+// Import
+// --------------------------------------------------------------------------------
+
+import { copyFileSync, mkdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// --------------------------------------------------------------------------------
+// Patch: Config Inspector
+// --------------------------------------------------------------------------------
+
+const configInspectorDirectory = dirname(
+  fileURLToPath(import.meta.resolve('@eslint/config-inspector/package.json')),
+);
+const publicDirectory = join(configInspectorDirectory, 'dist/public');
+const indexFile = join(publicDirectory, 'index.html');
+
+for (const route of ['configs', 'files', 'rules']) {
+  const routeDirectory = join(publicDirectory, route);
+
+  mkdirSync(routeDirectory, { recursive: true });
+  copyFileSync(indexFile, join(routeDirectory, 'index.html'));
+}


### PR DESCRIPTION
This pull request adds a patch script to the repository and updates the `prepare` script in `package.json` to run it automatically. The patch script ensures that the `@eslint/config-inspector` package's public routes are correctly set up by copying the main `index.html` file into specific subdirectories. The most important changes are:

**Build and packaging improvements:**
* Updated the `prepare` script in `package.json` to run both `husky` and a new patch script (`scripts/patch.js`), ensuring necessary post-install steps are automated.

**Tooling and patch automation:**
* Added `scripts/patch.js`, which copies the `index.html` file from the `@eslint/config-inspector` package into the `configs`, `files`, and `rules` subdirectories under its `dist/public` directory, ensuring these routes are available for the inspector UI.