### PR TITLE
docs(website): enhance documentation with `eslint-markdown` package details and navigation

### DIFF
--- a/website/.vitepress/config.js
+++ b/website/.vitepress/config.js
@@ -128,12 +128,17 @@ export default defineConfig({
     nav: [
       {
         text: 'Get Started',
-        activeMatch: '/docs/(?:get-started|community)',
+        activeMatch: '/docs/(?:get-started|packages|community)',
         items: [
           {
             text: 'Get Started',
             link: '/docs/get-started',
             activeMatch: '/docs/get-started',
+          },
+          {
+            text: 'Packages',
+            link: '/docs/packages/eslint-markdown',
+            activeMatch: '/docs/packages',
           },
           {
             text: 'Community',
@@ -204,6 +209,18 @@ export default defineConfig({
             {
               text: 'Versioning',
               link: 'versioning',
+            },
+          ],
+        },
+
+        {
+          base: '/docs/packages/',
+          text: 'Packages',
+          collapsed: false,
+          items: [
+            {
+              text: 'eslint-markdown',
+              link: 'eslint-markdown',
             },
           ],
         },

--- a/website/docs/packages/eslint-markdown.md
+++ b/website/docs/packages/eslint-markdown.md
@@ -1,0 +1,43 @@
+---
+description: "Package documentation for the `eslint-markdown` ESLint plugin."
+---
+
+# `eslint-markdown`
+
+> The Markdown plugin for ESLint.
+
+::: info
+
+See [Get Started](../get-started) for [installation](../get-started/installation) and [configuration](../get-started/configurations) guidance.
+
+:::
+
+`eslint-markdown` is an ESLint plugin that provides additional rules and shared configurations for linting Markdown. It is designed to work alongside ESLint's built-in Markdown support, [`@eslint/markdown`](https://github.com/eslint/markdown#readme), without duplicating its rules.
+
+## Config Inspector
+
+<!-- markdownlint-disable-next-line no-inline-html -->
+If you want to inspect the ESLint configuration for `eslint-markdown`, use the <a href="/inspector/eslint-markdown" target="_self">config inspector</a>.
+
+## Exports
+
+The package's default export is an ESLint plugin with the following properties:
+
+| Name      | Description                                                                           |
+| :-------- | :------------------------------------------------------------------------------------ |
+| `meta`    | Object containing the package `name` and `version`.                                   |
+| `rules`   | Object mapping rule names to the available [rule objects](../rules/).                 |
+| `configs` | Object containing the [`recommended`], [`stylistic`], [`base`], and [`all`] configs.  |
+
+[`recommended`]: ../get-started/configurations.md#recommended
+[`stylistic`]: ../get-started/configurations.md#stylistic
+[`base`]: ../get-started/configurations.md#base
+[`all`]: ../get-started/configurations.md#all
+
+```js
+import md from 'eslint-markdown';
+
+md.meta;
+md.rules;
+md.configs;
+```

--- a/website/docs/packages/eslint-markdown.md
+++ b/website/docs/packages/eslint-markdown.md
@@ -8,7 +8,7 @@ description: "Package documentation for the `eslint-markdown` ESLint plugin."
 
 ::: info
 
-See [Get Started](../get-started) for [installation](../get-started/installation) and [configuration](../get-started/configurations) guidance.
+See [Get Started](../get-started/) for [installation](../get-started/installation) and [configuration](../get-started/configurations) guidance.
 
 :::
 


### PR DESCRIPTION
This pull request adds documentation and navigation support for the new `eslint-markdown` package in the website. The most important changes include updating the navigation structure to include the new package and adding a dedicated documentation page for it.

**Navigation updates:**

* Updated the main navigation bar to add a "Packages" section, making it easier to find package documentation, and included an active match for `/docs/packages`.
* Added a sidebar group for "Packages" with an entry for `eslint-markdown` under `/docs/packages/`.

**Documentation:**

* Added a new documentation page at `website/docs/packages/eslint-markdown.md` describing the `eslint-markdown` ESLint plugin, its usage, configuration, and exports.