### PR TITLE
chore(release): bump package versions from `v0.14.0` to `v0.14.1` (`patch`)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "npm-eslint-markdown",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "npm-eslint-markdown",
-      "version": "0.14.0",
+      "version": "0.14.1",
       "workspaces": [
         "packages/*",
         "website"
@@ -10211,7 +10211,7 @@
       }
     },
     "packages/eslint-markdown": {
-      "version": "0.14.0",
+      "version": "0.14.1",
       "license": "MIT",
       "dependencies": {
         "@eslint/markdown": "^7.5.1",
@@ -10252,7 +10252,7 @@
         "@eslint/config-inspector": "^3.3.0",
         "@shikijs/transformers": "^3.20.0",
         "@shikijs/vitepress-twoslash": "^3.20.0",
-        "eslint-markdown": "^0.14.0",
+        "eslint-markdown": "^0.14.1",
         "twoslash-eslint": "^0.3.4",
         "vitepress": "2.0.0-alpha.17",
         "vitepress-plugin-group-icons": "^1.7.6"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "npm-eslint-markdown",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "type": "module",
   "packageManager": "npm@10.9.2",
   "engines": {

--- a/packages/eslint-markdown/package.json
+++ b/packages/eslint-markdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-markdown",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "type": "module",
   "sideEffects": false,
   "description": "Lint your Markdown with ESLint. Additional rules for use with `@eslint/markdown`.🛠️",

--- a/website/package.json
+++ b/website/package.json
@@ -16,7 +16,7 @@
     "@eslint/config-inspector": "^3.3.0",
     "@shikijs/transformers": "^3.20.0",
     "@shikijs/vitepress-twoslash": "^3.20.0",
-    "eslint-markdown": "^0.14.0",
+    "eslint-markdown": "^0.14.1",
     "twoslash-eslint": "^0.3.4",
     "vitepress": "2.0.0-alpha.17",
     "vitepress-plugin-group-icons": "^1.7.6"


### PR DESCRIPTION
## Release Information: `v0.14.1`

New release of `lumirlumir/npm-eslint-markdown` has arrived! :tada:

This PR bumps the package versions from `v0.14.0` to `v0.14.1` (`patch`).

See [Actions](https://github.com/lumirlumir/npm-eslint-markdown/actions/runs/33288781864) for more details.

| Info        | Value                      |
| ----------- | -------------------------- |
| Repository  | `lumirlumir/npm-eslint-markdown` |
| SEMVER      | `patch`     |
| Pre ID      | `canary`      |
| Short SHA   | 350c7eb       |
| Old Version | `v0.14.0`  |
| New Version | `v0.14.1`  |

<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
### :bug: Bug Fixes
* fix(eslint-markdown): improve messages for empty allow lists by @tooth-is-silver in https://github.com/lumirlumir/npm-eslint-markdown/pull/671
### :toolbox: Chores
* chore(website): consolidate config inspector by @lumirlumir in https://github.com/lumirlumir/npm-eslint-markdown/pull/659
* chore(website): add static fallbacks for config inspector routes by @lumirlumir in https://github.com/lumirlumir/npm-eslint-markdown/pull/660
* chore(sync-server): update `test:coverage` script by @lumirlumir in https://github.com/lumirlumir/npm-eslint-markdown/pull/664
### :memo: Documentation
* docs(website): enhance documentation with `eslint-markdown` package details and navigation by @lumirlumir in https://github.com/lumirlumir/npm-eslint-markdown/pull/662
* docs(*): add `CLAUDE.md` by @Grit03 in https://github.com/lumirlumir/npm-eslint-markdown/pull/668
* docs(eslint-markdown): add JSDoc to rule option types by @tooth-is-silver in https://github.com/lumirlumir/npm-eslint-markdown/pull/663
### :recycle: Code Refactoring
* refactor(eslint-markdown): derive consistent style types from constants by @tooth-is-silver in https://github.com/lumirlumir/npm-eslint-markdown/pull/667
* refactor(*): consolidate shared constants and named exports by @lumirlumir in https://github.com/lumirlumir/npm-eslint-markdown/pull/672

## New Contributors
* @Grit03 made their first contribution in https://github.com/lumirlumir/npm-eslint-markdown/pull/668

**Full Changelog**: https://github.com/lumirlumir/npm-eslint-markdown/compare/v0.14.0...v0.14.1