### PR TITLE
feat(eslint-markdown): add `skipMath` option to `no-git-conflict-marker`

### DIFF
--- a/packages/eslint-markdown/src/rules/no-git-conflict-marker.test.ts
+++ b/packages/eslint-markdown/src/rules/no-git-conflict-marker.test.ts
@@ -111,6 +111,81 @@ ruleTester('no-git-conflict-marker', rule, {
         },
       ],
     },
+
+    // skipMath Option
+    {
+      name: '`skipMath: true` default: math block should be skipped (`>`)',
+      code: `$$
+>>>>>>> ab18d2f0f5151ab0c927a12eb0a64f8170762eff
+$$`,
+      languageOptions: {
+        math: true,
+      },
+    },
+    {
+      name: '`skipMath: true` default: math block should be skipped (`=`)',
+      code: `$$
+=======
+$$`,
+      languageOptions: {
+        math: true,
+      },
+    },
+    {
+      name: '`skipMath: true` default: math block should be skipped (`<`)',
+      code: `$$
+<<<<<<< HEAD
+$$`,
+      languageOptions: {
+        math: true,
+      },
+    },
+    {
+      name: '`skipMath: true` explicit option: math block should be skipped',
+      code: `$$
+<<<<<<< HEAD
+=======
+>>>>>>> ab18d2f0f5151ab0c927a12eb0a64f8170762eff
+$$`,
+      options: [
+        {
+          skipMath: true,
+        },
+      ],
+      languageOptions: {
+        math: true,
+      },
+    },
+    {
+      name: '`skipMath: true, skipCode: false` options: math block should be skipped',
+      code: `$$
+<<<<<<< HEAD
+$$`,
+      options: [
+        {
+          skipCode: false,
+          skipMath: true,
+        },
+      ],
+      languageOptions: {
+        math: true,
+      },
+    },
+    {
+      name: '`skipMath: false, skipCode: true` options: code block should be skipped',
+      code: `\`\`\`md
+<<<<<<< HEAD
+\`\`\``,
+      options: [
+        {
+          skipCode: true,
+          skipMath: false,
+        },
+      ],
+      languageOptions: {
+        math: true,
+      },
+    },
   ],
 
   invalid: [
@@ -410,6 +485,219 @@ ruleTester('no-git-conflict-marker', rule, {
       options: [
         {
           skipCode: ['js', 'ts'],
+        },
+      ],
+    },
+
+    // skipMath Option
+    {
+      name: '`skipMath: false` option: math block should not be skipped (`<`)',
+      code: `$$
+<<<<<<< HEAD
+$$`,
+      output: `$$
+$$`,
+      errors: [
+        {
+          messageId: 'noGitConflictMarker',
+          line: 2,
+          column: 1,
+          endLine: 2,
+          endColumn: 8,
+          data: {
+            gitConflictMarker: '<<<<<<<',
+          },
+        },
+      ],
+      options: [
+        {
+          skipMath: false,
+        },
+      ],
+      languageOptions: {
+        math: true,
+      },
+    },
+    {
+      name: '`skipMath: false` option: math block should not be skipped (`=`)',
+      code: `$$
+=======
+$$`,
+      output: `$$
+$$`,
+      errors: [
+        {
+          messageId: 'noGitConflictMarker',
+          line: 2,
+          column: 1,
+          endLine: 2,
+          endColumn: 8,
+          data: {
+            gitConflictMarker: '=======',
+          },
+        },
+      ],
+      options: [
+        {
+          skipMath: false,
+        },
+      ],
+      languageOptions: {
+        math: true,
+      },
+    },
+    {
+      name: '`skipMath: false` option: math block should not be skipped (`>`)',
+      code: `$$
+>>>>>>> ab18d2f0f5151ab0c927a12eb0a64f8170762eff
+$$`,
+      output: `$$
+$$`,
+      errors: [
+        {
+          messageId: 'noGitConflictMarker',
+          line: 2,
+          column: 1,
+          endLine: 2,
+          endColumn: 8,
+          data: {
+            gitConflictMarker: '>>>>>>>',
+          },
+        },
+      ],
+      options: [
+        {
+          skipMath: false,
+        },
+      ],
+      languageOptions: {
+        math: true,
+      },
+    },
+    {
+      name: 'Markers outside math blocks should still be reported when math parsing is enabled',
+      code: `$$
+x = 1
+$$
+<<<<<<< HEAD
+outside`,
+      output: `$$
+x = 1
+$$
+outside`,
+      errors: [
+        {
+          messageId: 'noGitConflictMarker',
+          line: 4,
+          column: 1,
+          endLine: 4,
+          endColumn: 8,
+          data: {
+            gitConflictMarker: '<<<<<<<',
+          },
+        },
+      ],
+      options: [
+        {
+          skipMath: true,
+        },
+      ],
+      languageOptions: {
+        math: true,
+      },
+    },
+    {
+      name: '`skipMath: false, skipCode: true` options: code block is skipped but math block is reported',
+      code: `\`\`\`md
+<<<<<<< HEAD
+\`\`\`
+$$
+<<<<<<< HEAD
+$$`,
+      output: `\`\`\`md
+<<<<<<< HEAD
+\`\`\`
+$$
+$$`,
+      errors: [
+        {
+          messageId: 'noGitConflictMarker',
+          line: 5,
+          column: 1,
+          endLine: 5,
+          endColumn: 8,
+          data: {
+            gitConflictMarker: '<<<<<<<',
+          },
+        },
+      ],
+      options: [
+        {
+          skipCode: true,
+          skipMath: false,
+        },
+      ],
+      languageOptions: {
+        math: true,
+      },
+    },
+    {
+      name: '`skipMath: true, skipCode: false` options: math block is skipped but code block is reported',
+      code: `$$
+<<<<<<< HEAD
+$$
+\`\`\`md
+<<<<<<< HEAD
+\`\`\``,
+      output: `$$
+<<<<<<< HEAD
+$$
+\`\`\`md
+\`\`\``,
+      errors: [
+        {
+          messageId: 'noGitConflictMarker',
+          line: 5,
+          column: 1,
+          endLine: 5,
+          endColumn: 8,
+          data: {
+            gitConflictMarker: '<<<<<<<',
+          },
+        },
+      ],
+      options: [
+        {
+          skipCode: false,
+          skipMath: true,
+        },
+      ],
+      languageOptions: {
+        math: true,
+      },
+    },
+    {
+      name: 'Math parsing disabled: `skipMath: true` does not exclude text enclosed in math delimiters',
+      code: `$$
+<<<<<<< HEAD
+$$`,
+      output: `$$
+$$`,
+      errors: [
+        {
+          messageId: 'noGitConflictMarker',
+          line: 2,
+          column: 1,
+          endLine: 2,
+          endColumn: 8,
+          data: {
+            gitConflictMarker: '<<<<<<<',
+          },
+        },
+      ],
+      options: [
+        {
+          skipMath: true,
         },
       ],
     },

--- a/packages/eslint-markdown/src/rules/no-git-conflict-marker.test.ts
+++ b/packages/eslint-markdown/src/rules/no-git-conflict-marker.test.ts
@@ -111,8 +111,6 @@ ruleTester('no-git-conflict-marker', rule, {
         },
       ],
     },
-
-    // skipMath Option
     {
       name: '`skipMath: true` default: math block should be skipped (`>`)',
       code: `$$
@@ -488,8 +486,6 @@ $$`,
         },
       ],
     },
-
-    // skipMath Option
     {
       name: '`skipMath: false` option: math block should not be skipped (`<`)',
       code: `$$

--- a/packages/eslint-markdown/src/rules/no-git-conflict-marker.ts
+++ b/packages/eslint-markdown/src/rules/no-git-conflict-marker.ts
@@ -25,6 +25,11 @@ type RuleOptions = [
      * @default true
      */
     skipCode: boolean | string[];
+    /**
+     * `true` allows Git conflict markers in math blocks.
+     * @default true
+     */
+    skipMath: boolean;
   },
 ];
 type MessageIds = 'noGitConflictMarker';
@@ -71,6 +76,9 @@ export default {
               },
             ],
           },
+          skipMath: {
+            type: 'boolean',
+          },
         },
         additionalProperties: false,
       },
@@ -79,6 +87,7 @@ export default {
     defaultOptions: [
       {
         skipCode: true,
+        skipMath: true,
       },
     ],
 
@@ -94,7 +103,7 @@ export default {
 
   create(context) {
     const { sourceCode } = context;
-    const [{ skipCode }] = context.options;
+    const [{ skipCode, skipMath }] = context.options;
 
     const skipRanges = new SkipRanges();
 
@@ -104,6 +113,10 @@ export default {
           Array.isArray(skipCode) ? node.lang && skipCode.includes(node.lang) : skipCode
         )
           skipRanges.push(sourceCode.getRange(node)); // Store range information of `Code`.
+      },
+
+      math(node) {
+        if (skipMath) skipRanges.push(sourceCode.getRange(node)); // Store range information of `Math`.
       },
 
       'root:exit'() {

--- a/website/.vitepress/config.js
+++ b/website/.vitepress/config.js
@@ -297,7 +297,14 @@ export default defineConfig({
         errorRendering: 'hover',
         explicitTrigger: /\beslint-check\b/,
         twoslasher: createTwoslasher({
-          eslintConfig: [md.configs.base],
+          eslintConfig: [
+            md.configs.base,
+            {
+              languageOptions: {
+                math: true,
+              },
+            },
+          ],
         }),
       }),
     ],

--- a/website/docs/rules/no-git-conflict-marker.md
+++ b/website/docs/rules/no-git-conflict-marker.md
@@ -87,7 +87,9 @@ Examples of **incorrect** code for this rule:
 
 #### With `{ skipMath: false }` Option
 
-  ```md
+  ```md eslint-check
+  <!-- eslint md/no-git-conflict-marker: ['error', { skipMath: false }] -->
+
   # My Document
 
   $$
@@ -163,7 +165,9 @@ Examples of **correct** code for this rule:
 
 #### With `{ skipMath: true }` Option
 
-  ```md
+  ```md eslint-check
+  <!-- eslint md/no-git-conflict-marker: ['error', { skipMath: true }] -->
+
   # My Document
 
   $$
@@ -199,11 +203,7 @@ Examples of **correct** code for this rule:
 `true` allows Git conflict markers in math blocks.
 
 ::: tip NOTE
-This option requires enabling math parsing with `languageOptions: { math: true }`.
-:::
-
-::: warning
-Existing users with math parsing enabled will stop receiving reports inside math blocks by default. Setting `skipMath: false` preserves the previous behavior.
+This option requires enabling math parsing with [`languageOptions: { math: true }`](https://github.com/eslint/markdown#enabling-math-latex-in-both-commonmark-and-gfm).
 :::
 
 ## Fix

--- a/website/docs/rules/no-git-conflict-marker.md
+++ b/website/docs/rules/no-git-conflict-marker.md
@@ -85,6 +85,22 @@ Examples of **incorrect** code for this rule:
   ## Next Section
   ````
 
+#### With `{ skipMath: false }` Option
+
+  ```md
+  # My Document
+
+  $$
+  <<<<<<< HEAD
+  x = 1
+  =======
+  x = 2
+  >>>>>>> branch-name
+  $$
+
+  ## Next Section
+  ```
+
 ### :white_check_mark: Correct
 
 Examples of **correct** code for this rule:
@@ -145,11 +161,28 @@ Examples of **correct** code for this rule:
   ## Next Section
   ````  
 
+#### With `{ skipMath: true }` Option
+
+  ```md
+  # My Document
+
+  $$
+  <<<<<<< HEAD
+  x = 1
+  =======
+  x = 2
+  >>>>>>> branch-name
+  $$
+
+  ## Next Section
+  ```
+
 ## Options
 
 ```js
 'md/no-git-conflict-marker': ['error', {
   skipCode: true,
+  skipMath: true,
 }]
 ```
 
@@ -158,6 +191,20 @@ Examples of **correct** code for this rule:
 > Type: `boolean | string[]` / Default: `true`
 
 `true` allows Git conflict markers in all code blocks, while `string[]` allows Git conflict markers only in code blocks for the specified languages.
+
+### `skipMath`
+
+> Type: `boolean` / Default: `true`
+
+`true` allows Git conflict markers in math blocks.
+
+::: tip NOTE
+This option requires enabling math parsing with `languageOptions: { math: true }`.
+:::
+
+::: warning
+Existing users with math parsing enabled will stop receiving reports inside math blocks by default. Setting `skipMath: false` preserves the previous behavior.
+:::
 
 ## Fix
 


### PR DESCRIPTION
## Overview
Closes #686.

Adds a `skipMath` option to the `no-git-conflict-marker` rule in `eslint-markdown`, allowing users to exclude Git conflict markers inside math blocks when math parsing is enabled (`languageOptions: { math: true }`).

## Proposed Changes
1. **Rule update** (`packages/eslint-markdown/src/rules/no-git-conflict-marker.ts`):
   - Added `skipMath: boolean` to `RuleOptions`.
   - Registered `skipMath` as a boolean property in `meta.schema`.
   - Set default value to `true` in `meta.defaultOptions`.
   - Added `math(node)` listener in `create()` to record math block ranges into `skipRanges` when `skipMath` is enabled.
2. **Tests** (`packages/eslint-markdown/src/rules/no-git-conflict-marker.test.ts`):
   - Verified that with math parsing enabled, markers inside math blocks are skipped by default and with explicit `skipMath: true`.
   - Verified that with `skipMath: false`, markers inside math blocks are reported.
   - Verified that markers outside math blocks are still reported.
   - Verified that `skipMath` and `skipCode` work independently.
   - Verified that with math parsing disabled, `skipMath: true` does not exclude text merely enclosed in math delimiters.
3. **Documentation** (`website/docs/rules/no-git-conflict-marker.md`):
   - Documented the option's type (`boolean`), default (`true`), and behavior.
   - Added examples for `skipMath: false` (incorrect) and `skipMath: true` (correct).
   - Documented the requirement to enable math parsing via `languageOptions: { math: true }`.

## Validation
- `npm run test` (type check + 2193 unit tests passed).
- `npm run build` (packages build + website VitePress build passed).
- `npm run lint` (eslint, prettier, editorconfig, markdownlint passed).