### PR TITLE
feat(eslint-markdown): add `skipMath` and `skipInlineMath` options to `no-irregular-dash`

### DIFF
--- a/packages/eslint-markdown/src/rules/no-irregular-dash.test.ts
+++ b/packages/eslint-markdown/src/rules/no-irregular-dash.test.ts
@@ -78,6 +78,93 @@ console.log(\u2014'Hello World');
         },
       ],
     },
+
+    // skipMath and skipInlineMath Options
+    {
+      name: '`skipMath: true` default: math block should be skipped',
+      code: `$$
+x \u2212 y = 0
+$$`,
+      languageOptions: {
+        math: true,
+      },
+    },
+    {
+      name: '`skipInlineMath: true` default: inline math should be skipped',
+      code: `$x \u2212 y$`,
+      languageOptions: {
+        math: true,
+      },
+    },
+    {
+      name: '`skipMath: true` explicit option: math block should be skipped',
+      code: `$$
+x \u2212 y = 0
+$$`,
+      options: [
+        {
+          skipMath: true,
+        },
+      ],
+      languageOptions: {
+        math: true,
+      },
+    },
+    {
+      name: '`skipInlineMath: true` explicit option: inline math should be skipped',
+      code: `$x \u2212 y$`,
+      options: [
+        {
+          skipInlineMath: true,
+        },
+      ],
+      languageOptions: {
+        math: true,
+      },
+    },
+    {
+      name: '`skipMath: true, skipInlineMath: false` options: math block should be skipped',
+      code: `$$
+x \u2212 y = 0
+$$`,
+      options: [
+        {
+          skipMath: true,
+          skipInlineMath: false,
+        },
+      ],
+      languageOptions: {
+        math: true,
+      },
+    },
+    {
+      name: '`skipMath: false, skipInlineMath: true` options: inline math should be skipped',
+      code: `$x \u2212 y$`,
+      options: [
+        {
+          skipMath: false,
+          skipInlineMath: true,
+        },
+      ],
+      languageOptions: {
+        math: true,
+      },
+    },
+    {
+      name: 'Irregular dash outside math block allowed by `allow` option',
+      code: `$$
+x \u2212 y
+$$
+a \u2013 b`,
+      options: [
+        {
+          allow: ['\u2013'],
+        },
+      ],
+      languageOptions: {
+        math: true,
+      },
+    },
   ],
 
   invalid: [
@@ -356,6 +443,180 @@ Foo\u2010Bar
       options: [
         {
           skipInlineCode: false,
+        },
+      ],
+    },
+
+    // skipMath and skipInlineMath Options
+    {
+      name: '`skipMath: false` option: math block should not be skipped',
+      code: `$$
+x \u2212 y
+$$`,
+      errors: [
+        {
+          messageId: 'noIrregularDash',
+          line: 2,
+          column: 3,
+          endLine: 2,
+          endColumn: 4,
+          data: {
+            irregularDash: 'U+2212',
+          },
+        },
+      ],
+      options: [
+        {
+          skipMath: false,
+        },
+      ],
+      languageOptions: {
+        math: true,
+      },
+    },
+    {
+      name: '`skipInlineMath: false` option: inline math should not be skipped',
+      code: `$x \u2212 y$`,
+      errors: [
+        {
+          messageId: 'noIrregularDash',
+          line: 1,
+          column: 4,
+          endLine: 1,
+          endColumn: 5,
+          data: {
+            irregularDash: 'U+2212',
+          },
+        },
+      ],
+      options: [
+        {
+          skipInlineMath: false,
+        },
+      ],
+      languageOptions: {
+        math: true,
+      },
+    },
+    {
+      name: '`skipMath: false, skipInlineMath: true` options: math block is reported',
+      code: `$$
+x \u2212 y
+$$
+$a \u2212 b$`,
+      errors: [
+        {
+          messageId: 'noIrregularDash',
+          line: 2,
+          column: 3,
+          endLine: 2,
+          endColumn: 4,
+          data: {
+            irregularDash: 'U+2212',
+          },
+        },
+      ],
+      options: [
+        {
+          skipMath: false,
+          skipInlineMath: true,
+        },
+      ],
+      languageOptions: {
+        math: true,
+      },
+    },
+    {
+      name: '`skipMath: true, skipInlineMath: false` options: inline math is reported',
+      code: `$$
+x \u2212 y
+$$
+$a \u2212 b$`,
+      errors: [
+        {
+          messageId: 'noIrregularDash',
+          line: 4,
+          column: 4,
+          endLine: 4,
+          endColumn: 5,
+          data: {
+            irregularDash: 'U+2212',
+          },
+        },
+      ],
+      options: [
+        {
+          skipMath: true,
+          skipInlineMath: false,
+        },
+      ],
+      languageOptions: {
+        math: true,
+      },
+    },
+    {
+      name: 'Irregular dash outside math region is reported when not permitted by `allow`',
+      code: `$$
+x \u2212 y
+$$
+outside \u2013 dash`,
+      errors: [
+        {
+          messageId: 'noIrregularDash',
+          line: 4,
+          column: 9,
+          endLine: 4,
+          endColumn: 10,
+          data: {
+            irregularDash: 'U+2013',
+          },
+        },
+      ],
+      languageOptions: {
+        math: true,
+      },
+    },
+    {
+      name: 'Math parsing disabled: `skipMath: true` does not exclude text in math block delimiters',
+      code: `$$
+x \u2212 y
+$$`,
+      errors: [
+        {
+          messageId: 'noIrregularDash',
+          line: 2,
+          column: 3,
+          endLine: 2,
+          endColumn: 4,
+          data: {
+            irregularDash: 'U+2212',
+          },
+        },
+      ],
+      options: [
+        {
+          skipMath: true,
+        },
+      ],
+    },
+    {
+      name: 'Math parsing disabled: `skipInlineMath: true` does not exclude text in inline math delimiters',
+      code: `$x \u2212 y$`,
+      errors: [
+        {
+          messageId: 'noIrregularDash',
+          line: 1,
+          column: 4,
+          endLine: 1,
+          endColumn: 5,
+          data: {
+            irregularDash: 'U+2212',
+          },
+        },
+      ],
+      options: [
+        {
+          skipInlineMath: true,
         },
       ],
     },

--- a/packages/eslint-markdown/src/rules/no-irregular-dash.ts
+++ b/packages/eslint-markdown/src/rules/no-irregular-dash.ts
@@ -37,6 +37,16 @@ type RuleOptions = [
      * @default true
      */
     skipInlineCode: boolean;
+    /**
+     * `true` allows irregular dashes in math blocks.
+     * @default true
+     */
+    skipMath: boolean;
+    /**
+     * `true` allows irregular dashes in inline math.
+     * @default true
+     */
+    skipInlineMath: boolean;
   },
 ];
 type MessageIds = 'noIrregularDash';
@@ -91,6 +101,12 @@ export default {
           skipInlineCode: {
             type: 'boolean',
           },
+          skipMath: {
+            type: 'boolean',
+          },
+          skipInlineMath: {
+            type: 'boolean',
+          },
         },
         additionalProperties: false,
       },
@@ -101,6 +117,8 @@ export default {
         allow: [],
         skipCode: true,
         skipInlineCode: true,
+        skipMath: true,
+        skipInlineMath: true,
       },
     ],
 
@@ -115,7 +133,8 @@ export default {
 
   create(context) {
     const { sourceCode } = context;
-    const [{ allow, skipCode, skipInlineCode }] = context.options;
+    const [{ allow, skipCode, skipInlineCode, skipMath, skipInlineMath }] =
+      context.options;
 
     const skipRanges = new SkipRanges();
 
@@ -129,6 +148,14 @@ export default {
 
       inlineCode(node) {
         if (skipInlineCode) skipRanges.push(sourceCode.getRange(node)); // Store range information of `InlineCode`.
+      },
+
+      math(node) {
+        if (skipMath) skipRanges.push(sourceCode.getRange(node)); // Store range information of `Math`.
+      },
+
+      inlineMath(node) {
+        if (skipInlineMath) skipRanges.push(sourceCode.getRange(node)); // Store range information of `InlineMath`.
       },
 
       'root:exit'() {

--- a/website/docs/rules/no-irregular-dash.md
+++ b/website/docs/rules/no-irregular-dash.md
@@ -109,6 +109,28 @@ Examples of **incorrect** code for this rule:
 \u2011 - Non-Breaking Hyphen - <NBHY> `‑` <= Here
 ```
 
+#### With `{ skipMath: false }` Option
+
+  ```md
+  # My Document
+
+  $$
+  x \u2212 y = 0
+  $$
+
+  ## Next Section
+  ```
+
+#### With `{ skipInlineMath: false }` Option
+
+  ```md
+  # My Document
+
+  $x \u2212 y = 0$
+
+  ## Next Section
+  ```
+
 ### :white_check_mark: Correct
 
 Examples of **correct** code for this rule:
@@ -179,6 +201,28 @@ Examples of **correct** code for this rule:
 \u2011 - Non-Breaking Hyphen - <NBHY> `‑` <= Here
 ```
 
+#### With `{ skipMath: true }` Option
+
+  ```md
+  # My Document
+
+  $$
+  x \u2212 y = 0
+  $$
+
+  ## Next Section
+  ```
+
+#### With `{ skipInlineMath: true }` Option
+
+  ```md
+  # My Document
+
+  $x \u2212 y = 0$
+
+  ## Next Section
+  ```
+
 ## Options
 
 ```js
@@ -186,6 +230,8 @@ Examples of **correct** code for this rule:
   allow: [],
   skipCode: true,
   skipInlineCode: true,
+  skipMath: true,
+  skipInlineMath: true,
 }]
 ```
 
@@ -206,6 +252,34 @@ When specified, specific irregular dash characters are allowed if they match one
 > Type: `boolean` / Default: `true`
 
 `true` allows irregular dashes in all inline code.
+
+### `skipMath`
+
+> Type: `boolean` / Default: `true`
+
+`true` allows irregular dashes in math blocks.
+
+::: tip NOTE
+This option requires enabling math parsing with `languageOptions: { math: true }`.
+:::
+
+::: warning
+Existing users with math parsing enabled will stop receiving reports inside math blocks by default. Setting `skipMath: false` preserves the previous behavior.
+:::
+
+### `skipInlineMath`
+
+> Type: `boolean` / Default: `true`
+
+`true` allows irregular dashes in inline math.
+
+::: tip NOTE
+This option requires enabling math parsing with `languageOptions: { math: true }`.
+:::
+
+::: warning
+Existing users with math parsing enabled will stop receiving reports inside inline math by default. Setting `skipInlineMath: false` preserves the previous behavior.
+:::
 
 ## When Not To Use It
 


### PR DESCRIPTION
## Overview

Closes #687.

Adds `skipMath` and `skipInlineMath` options to the `no-irregular-dash` rule in `eslint-markdown`, allowing users to exclude irregular dashes (such as Unicode minus sign `−`, U+2212) inside math blocks and inline math when math parsing is enabled (`languageOptions: { math: true }`).

## Proposed Changes

1. **Rule update** (`packages/eslint-markdown/src/rules/no-irregular-dash.ts`):
   - Added `skipMath: boolean` and `skipInlineMath: boolean` to `RuleOptions`.
   - Registered both as boolean properties in `meta.schema`.
   - Set default values to `true` in `meta.defaultOptions`.
   - Added `math(node)` and `inlineMath(node)` listeners in `create()` to record ranges into `skipRanges` when the corresponding option is enabled.
2. **Tests** (`packages/eslint-markdown/src/rules/no-irregular-dash.test.ts`):
   - Verified that with math parsing enabled, irregular dashes inside math blocks and inline math are skipped by default and with explicit `true` options.
   - Verified that `skipMath: false` causes irregular dashes inside math blocks to be reported.
   - Verified that `skipInlineMath: false` causes irregular dashes inside inline math to be reported.
   - Verified that the two options work independently.
   - Verified that irregular dashes outside excluded math regions are still reported unless permitted by `allow`.
   - Verified that with math parsing disabled, the options do not exclude text merely enclosed in math delimiters.
3. **Documentation** (`website/docs/rules/no-irregular-dash.md`):
   - Documented each option's type (`boolean`), default (`true`), and behavior.
   - Added examples for options enabled and disabled.
   - Documented the requirement to enable math parsing via `languageOptions: { math: true }`.

## Validation

- `npm run test` (type check + 2,195 unit tests passed).
- `npm run build` (packages build + website VitePress build passed).
- `npm run lint` (eslint, prettier, editorconfig, markdownlint passed).