### PR TITLE
feat(eslint-markdown): add `skipMath` and `skipInlineMath` options to `no-irregular-whitespace`

### DIFF
--- a/packages/eslint-markdown/src/rules/no-irregular-whitespace.test.ts
+++ b/packages/eslint-markdown/src/rules/no-irregular-whitespace.test.ts
@@ -78,6 +78,67 @@ console.log(\u200b'Hello World');
         },
       ],
     },
+    {
+      name: '`skipMath: true` default: math block should be skipped',
+      code: `$$
+\\int f(x)\\,dx = \\sum a_i\\u2009b_i
+$$`,
+      languageOptions: {
+        math: true,
+      },
+    },
+    {
+      name: '`skipInlineMath: true` default: inline math should be skipped',
+      code: '$f(x)\\u2009dx$',
+      languageOptions: {
+        math: true,
+      },
+    },
+    {
+      name: '`skipMath: true, skipInlineMath: true` explicit options: math regions should be skipped',
+      code: `$$
+\\int f(x)\\u202Fdx
+$$
+
+$a\\u2009b$`,
+      options: [
+        {
+          skipMath: true,
+          skipInlineMath: true,
+        },
+      ],
+      languageOptions: {
+        math: true,
+      },
+    },
+    {
+      name: '`skipMath: true, skipInlineMath: false` mixed options: math block is skipped',
+      code: `$$
+\\int f(x)\\u2009dx
+$$`,
+      options: [
+        {
+          skipMath: true,
+          skipInlineMath: false,
+        },
+      ],
+      languageOptions: {
+        math: true,
+      },
+    },
+    {
+      name: '`skipMath: false, skipInlineMath: true` mixed options: inline math is skipped',
+      code: '$f(x)\\u2009dx$',
+      options: [
+        {
+          skipMath: false,
+          skipInlineMath: true,
+        },
+      ],
+      languageOptions: {
+        math: true,
+      },
+    },
   ],
 
   invalid: [
@@ -447,6 +508,181 @@ Foo\u00a0Bar
       options: [
         {
           skipInlineCode: false,
+        },
+      ],
+    },
+    {
+      name: '`skipMath: false` option: math block should not be skipped',
+      code: `$$
+x\u2009y
+$$`,
+      errors: [
+        {
+          messageId: 'noIrregularWhitespace',
+          line: 2,
+          column: 2,
+          endLine: 2,
+          endColumn: 3,
+          data: {
+            irregularWhitespace: 'U+2009',
+          },
+        },
+      ],
+      options: [
+        {
+          skipMath: false,
+        },
+      ],
+      languageOptions: {
+        math: true,
+      },
+    },
+    {
+      name: '`skipInlineMath: false` option: inline math should not be skipped',
+      code: '$x\u202Fy$',
+      errors: [
+        {
+          messageId: 'noIrregularWhitespace',
+          line: 1,
+          column: 3,
+          endLine: 1,
+          endColumn: 4,
+          data: {
+            irregularWhitespace: 'U+202F',
+          },
+        },
+      ],
+      options: [
+        {
+          skipInlineMath: false,
+        },
+      ],
+      languageOptions: {
+        math: true,
+      },
+    },
+    {
+      name: '`skipMath: false, skipInlineMath: true` options: math block is reported but inline math is skipped',
+      code: `$$
+x\u2009y
+$$
+
+$a\u2009b$`,
+      errors: [
+        {
+          messageId: 'noIrregularWhitespace',
+          line: 2,
+          column: 2,
+          endLine: 2,
+          endColumn: 3,
+          data: {
+            irregularWhitespace: 'U+2009',
+          },
+        },
+      ],
+      options: [
+        {
+          skipMath: false,
+          skipInlineMath: true,
+        },
+      ],
+      languageOptions: {
+        math: true,
+      },
+    },
+    {
+      name: '`skipMath: true, skipInlineMath: false` options: inline math is reported but math block is skipped',
+      code: `$$
+x\u2009y
+$$
+
+$a\u2009b$`,
+      errors: [
+        {
+          messageId: 'noIrregularWhitespace',
+          line: 5,
+          column: 3,
+          endLine: 5,
+          endColumn: 4,
+          data: {
+            irregularWhitespace: 'U+2009',
+          },
+        },
+      ],
+      options: [
+        {
+          skipMath: true,
+          skipInlineMath: false,
+        },
+      ],
+      languageOptions: {
+        math: true,
+      },
+    },
+    {
+      name: '`skipMath: true, skipInlineMath: true` options: whitespace in surrounding prose is reported',
+      code: `Prose\u2009with whitespace
+
+$$
+x\u2009y
+$$
+
+$a\u2009b$`,
+      errors: [
+        {
+          messageId: 'noIrregularWhitespace',
+          line: 1,
+          column: 6,
+          endLine: 1,
+          endColumn: 7,
+          data: {
+            irregularWhitespace: 'U+2009',
+          },
+        },
+      ],
+      options: [
+        {
+          skipMath: true,
+          skipInlineMath: true,
+        },
+      ],
+      languageOptions: {
+        math: true,
+      },
+    },
+    {
+      name: 'Math parsing disabled: `skipMath: true, skipInlineMath: true` does not exclude delimiters in plain text',
+      code: `$$
+x\u2009y
+$$
+
+$a\u202Fb$`,
+      errors: [
+        {
+          messageId: 'noIrregularWhitespace',
+          line: 2,
+          column: 2,
+          endLine: 2,
+          endColumn: 3,
+          data: {
+            irregularWhitespace: 'U+2009',
+          },
+        },
+        {
+          messageId: 'noIrregularWhitespace',
+          line: 5,
+          column: 3,
+          endLine: 5,
+          endColumn: 4,
+          data: {
+            irregularWhitespace: 'U+202F',
+          },
+        },
+      ],
+      options: [
+        {
+          skipMath: true,
+          skipInlineMath: true,
         },
       ],
     },

--- a/packages/eslint-markdown/src/rules/no-irregular-whitespace.test.ts
+++ b/packages/eslint-markdown/src/rules/no-irregular-whitespace.test.ts
@@ -79,28 +79,28 @@ console.log(\u200b'Hello World');
       ],
     },
     {
-      name: '`skipMath: true` default: math block should be skipped',
+      name: '`skipMath: true` - math block should be skipped',
       code: `$$
-\\int f(x)\\,dx = \\sum a_i\\u2009b_i
+x\u2009y
 $$`,
       languageOptions: {
         math: true,
       },
     },
     {
-      name: '`skipInlineMath: true` default: inline math should be skipped',
-      code: '$f(x)\\u2009dx$',
+      name: '`skipInlineMath: true` - inline math should be skipped',
+      code: '$a\u2009b$',
       languageOptions: {
         math: true,
       },
     },
     {
-      name: '`skipMath: true, skipInlineMath: true` explicit options: math regions should be skipped',
+      name: '`skipMath: true, skipInlineMath: true` - math regions should be skipped',
       code: `$$
-\\int f(x)\\u202Fdx
+x\u202Fy
 $$
 
-$a\\u2009b$`,
+$a\u2009b$`,
       options: [
         {
           skipMath: true,
@@ -112,9 +112,9 @@ $a\\u2009b$`,
       },
     },
     {
-      name: '`skipMath: true, skipInlineMath: false` mixed options: math block is skipped',
+      name: '`skipMath: true, skipInlineMath: false` - math block is skipped',
       code: `$$
-\\int f(x)\\u2009dx
+x\u2009y
 $$`,
       options: [
         {
@@ -127,8 +127,8 @@ $$`,
       },
     },
     {
-      name: '`skipMath: false, skipInlineMath: true` mixed options: inline math is skipped',
-      code: '$f(x)\\u2009dx$',
+      name: '`skipMath: false, skipInlineMath: true` - inline math is skipped',
+      code: '$a\u2009b$',
       options: [
         {
           skipMath: false,
@@ -512,7 +512,7 @@ Foo\u00a0Bar
       ],
     },
     {
-      name: '`skipMath: false` option: math block should not be skipped',
+      name: '`skipMath: false` - math block should not be skipped',
       code: `$$
 x\u2009y
 $$`,
@@ -538,7 +538,7 @@ $$`,
       },
     },
     {
-      name: '`skipInlineMath: false` option: inline math should not be skipped',
+      name: '`skipInlineMath: false` - inline math should not be skipped',
       code: '$x\u202Fy$',
       errors: [
         {
@@ -562,7 +562,7 @@ $$`,
       },
     },
     {
-      name: '`skipMath: false, skipInlineMath: true` options: math block is reported but inline math is skipped',
+      name: '`skipMath: false, skipInlineMath: true` - math block is reported but inline math is skipped',
       code: `$$
 x\u2009y
 $$
@@ -591,7 +591,7 @@ $a\u2009b$`,
       },
     },
     {
-      name: '`skipMath: true, skipInlineMath: false` options: inline math is reported but math block is skipped',
+      name: '`skipMath: true, skipInlineMath: false` - inline math is reported but math block is skipped',
       code: `$$
 x\u2009y
 $$
@@ -620,7 +620,7 @@ $a\u2009b$`,
       },
     },
     {
-      name: '`skipMath: true, skipInlineMath: true` options: whitespace in surrounding prose is reported',
+      name: '`skipMath: true, skipInlineMath: true` - whitespace in surrounding prose is reported',
       code: `Prose\u2009with whitespace
 
 $$
@@ -651,7 +651,7 @@ $a\u2009b$`,
       },
     },
     {
-      name: 'Math parsing disabled: `skipMath: true, skipInlineMath: true` does not exclude delimiters in plain text',
+      name: '`skipMath: true, skipInlineMath: true` - delimiters in plain text are not excluded when math parsing is disabled',
       code: `$$
 x\u2009y
 $$

--- a/packages/eslint-markdown/src/rules/no-irregular-whitespace.ts
+++ b/packages/eslint-markdown/src/rules/no-irregular-whitespace.ts
@@ -37,6 +37,16 @@ type RuleOptions = [
      * @default true
      */
     skipInlineCode: boolean;
+    /**
+     * `true` allows irregular whitespaces in all math blocks.
+     * @default true
+     */
+    skipMath: boolean;
+    /**
+     * `true` allows irregular whitespaces in all inline math.
+     * @default true
+     */
+    skipInlineMath: boolean;
   },
 ];
 type MessageIds = 'noIrregularWhitespace';
@@ -91,6 +101,12 @@ export default {
           skipInlineCode: {
             type: 'boolean',
           },
+          skipMath: {
+            type: 'boolean',
+          },
+          skipInlineMath: {
+            type: 'boolean',
+          },
         },
         additionalProperties: false,
       },
@@ -101,6 +117,8 @@ export default {
         allow: [],
         skipCode: true,
         skipInlineCode: true,
+        skipMath: true,
+        skipInlineMath: true,
       },
     ],
 
@@ -116,7 +134,8 @@ export default {
 
   create(context) {
     const { sourceCode } = context;
-    const [{ allow, skipCode, skipInlineCode }] = context.options;
+    const [{ allow, skipCode, skipInlineCode, skipMath, skipInlineMath }] =
+      context.options;
 
     const skipRanges = new SkipRanges();
 
@@ -130,6 +149,14 @@ export default {
 
       inlineCode(node) {
         if (skipInlineCode) skipRanges.push(sourceCode.getRange(node)); // Store range information of `InlineCode`.
+      },
+
+      math(node) {
+        if (skipMath) skipRanges.push(sourceCode.getRange(node)); // Store range information of `Math`.
+      },
+
+      inlineMath(node) {
+        if (skipInlineMath) skipRanges.push(sourceCode.getRange(node)); // Store range information of `InlineMath`.
       },
 
       'root:exit'() {

--- a/website/docs/rules/no-irregular-whitespace.md
+++ b/website/docs/rules/no-irregular-whitespace.md
@@ -132,6 +132,26 @@ Examples of **incorrect** code for this rule:
 \u0085 - Next Line - <NEL> `` <= Here
 ```
 
+#### With `{ skipMath: false }` Option
+
+```md eslint-check
+<!-- eslint md/no-irregular-whitespace: ['error', { skipMath: false }] -->
+
+$$
+\u000B - Line Tabulation (\v) - <VT>  <= Here
+\u0085 - Next Line - <NEL>  <= Here
+$$
+```
+
+#### With `{ skipInlineMath: false }` Option
+
+```md eslint-check
+<!-- eslint md/no-irregular-whitespace: ['error', { skipInlineMath: false }] -->
+
+$\u000B - Line Tabulation (\v) - <VT>  <= Here$
+$\u0085 - Next Line - <NEL>  <= Here$
+```
+
 ### :white_check_mark: Correct
 
 Examples of **correct** code for this rule:
@@ -207,6 +227,26 @@ Examples of **correct** code for this rule:
 \u0085 - Next Line - <NEL> `` <= Here
 ```
 
+#### With `{ skipMath: true }` Option
+
+```md eslint-check
+<!-- eslint md/no-irregular-whitespace: ['error', { skipMath: true }] -->
+
+$$
+\u000B - Line Tabulation (\v) - <VT>  <= Here
+\u0085 - Next Line - <NEL>  <= Here
+$$
+```
+
+#### With `{ skipInlineMath: true }` Option
+
+```md eslint-check
+<!-- eslint md/no-irregular-whitespace: ['error', { skipInlineMath: true }] -->
+
+$\u000B - Line Tabulation (\v) - <VT>  <= Here$
+$\u0085 - Next Line - <NEL>  <= Here$
+```
+
 ## Options
 
 ```js
@@ -214,6 +254,8 @@ Examples of **correct** code for this rule:
   allow: [],
   skipCode: true,
   skipInlineCode: true,
+  skipMath: true,
+  skipInlineMath: true,
 }]
 ```
 
@@ -234,6 +276,26 @@ When specified, specific irregular whitespaces are allowed if they match one of 
 > Type: `boolean` / Default: `true`
 
 `true` allows irregular whitespaces in all inline code.
+
+### `skipMath`
+
+> Type: `boolean` / Default: `true`
+
+`true` allows irregular whitespaces in all math blocks.
+
+::: tip NOTE
+This option requires enabling math parsing with [`languageOptions: { math: true }`](https://github.com/eslint/markdown#enabling-math-latex-in-both-commonmark-and-gfm).
+:::
+
+### `skipInlineMath`
+
+> Type: `boolean` / Default: `true`
+
+`true` allows irregular whitespaces in all inline math.
+
+::: tip NOTE
+This option requires enabling math parsing with [`languageOptions: { math: true }`](https://github.com/eslint/markdown#enabling-math-latex-in-both-commonmark-and-gfm).
+:::
 
 ## When Not To Use It
 

--- a/website/docs/rules/no-irregular-whitespace.md
+++ b/website/docs/rules/no-irregular-whitespace.md
@@ -148,8 +148,8 @@ $$
 ```md eslint-check
 <!-- eslint md/no-irregular-whitespace: ['error', { skipInlineMath: false }] -->
 
-$\u000B - Line Tabulation (\v) - <VT>  <= Here$
-$\u0085 - Next Line - <NEL>  <= Here$
+\u000B - Line Tabulation (\v) - <VT> $$ <= Here
+\u0085 - Next Line - <NEL> $$ <= Here
 ```
 
 ### :white_check_mark: Correct
@@ -243,8 +243,8 @@ $$
 ```md eslint-check
 <!-- eslint md/no-irregular-whitespace: ['error', { skipInlineMath: true }] -->
 
-$\u000B - Line Tabulation (\v) - <VT>  <= Here$
-$\u0085 - Next Line - <NEL>  <= Here$
+\u000B - Line Tabulation (\v) - <VT> $$ <= Here
+\u0085 - Next Line - <NEL> $$ <= Here
 ```
 
 ## Options


### PR DESCRIPTION
## Overview

Closes #689.

Adds `skipMath` and `skipInlineMath` options to the `no-irregular-whitespace` rule in `eslint-markdown`, allowing users to exclude irregular whitespace (such as thin space `\u2009` and narrow no-break space `\u202F`) inside math blocks and inline math when math parsing is enabled (`languageOptions: { math: true }`).

## Proposed Changes

1. **Rule update** (`packages/eslint-markdown/src/rules/no-irregular-whitespace.ts`):
   - Added `skipMath: boolean` and `skipInlineMath: boolean` to `RuleOptions`.
   - Registered both as boolean properties in `meta.schema`.
   - Set default values to `true` in `meta.defaultOptions`.
   - Added `math(node)` and `inlineMath(node)` listeners in `create()` to record ranges into `skipRanges` when the corresponding option is enabled.
2. **Tests** (`packages/eslint-markdown/src/rules/no-irregular-whitespace.test.ts`):
   - Verified that with math parsing enabled, irregular whitespace inside both math forms is skipped by default and with explicit `true` options.
   - Verified that `skipMath: false` causes irregular whitespace inside math blocks to be reported.
   - Verified that `skipInlineMath: false` causes irregular whitespace inside inline math to be reported.
   - Verified that the two options work independently, including both mixed combinations.
   - Verified that whitespace in surrounding prose is still reported unless permitted by `allow`.
   - Verified that with math parsing disabled, math delimiters alone do not exclude characters.
3. **Documentation** (`website/docs/rules/no-irregular-whitespace.md`):
   - Documented each option's type (`boolean`), default (`true`), and behavior.
   - Added examples for options enabled and disabled.
   - Documented the requirement to enable math parsing via `languageOptions: { math: true }`.

## Validation

- `npm run test` (type check + 2,215 unit tests passed).
- `npm run build` (packages build + website VitePress build passed).
- `npm run lint` (eslint, prettier, editorconfig, markdownlint passed).