### PR TITLE
fix(eslint-markdown): support custom namespaces in extended configs

### DIFF
--- a/packages/eslint-markdown/src/index.test-d.ts
+++ b/packages/eslint-markdown/src/index.test-d.ts
@@ -27,6 +27,7 @@ plugin satisfies ESLint.Plugin;
 // #region meta
 
 plugin.meta.name satisfies 'eslint-markdown';
+plugin.meta.namespace satisfies 'md';
 plugin.meta.version satisfies string;
 
 // #endregion meta

--- a/packages/eslint-markdown/src/index.test.ts
+++ b/packages/eslint-markdown/src/index.test.ts
@@ -30,6 +30,7 @@ describe('index', () => {
   describe('Basic', () => {
     it('should have correct meta information', () => {
       assert.strictEqual(md.meta.name, 'eslint-markdown');
+      assert.strictEqual(md.meta.namespace, 'md');
       assert.strictEqual(typeof md.meta.version, 'string');
     });
 
@@ -67,6 +68,46 @@ describe('index', () => {
       for (const stylisticConfigRuleName of Object.keys(md.configs.stylistic.rules)) {
         assert.strictEqual(stylisticConfigRuleName.startsWith('md/'), true);
       }
+    });
+  });
+
+  describe('Custom namespaces in extends style configurations', () => {
+    it('should report the custom rule ID when extending the exported plugin', () => {
+      const linter = new Linter();
+      const config = defineConfig([
+        {
+          files: ['**/*.md'],
+          plugins: {
+            custommd: md,
+          },
+          extends: ['custommd/recommended'],
+        },
+      ]);
+      const messages = linter.verify('12  34', config, { filename: 'test.md' });
+
+      assert.strictEqual(messages.length, 1);
+      assert.strictEqual(messages[0].ruleId, 'custommd/no-double-space');
+      assert.strictEqual(messages[0].messageId, 'noDoubleSpace');
+      assert.strictEqual(messages[0].severity, 2);
+    });
+
+    it('should disable the inherited rule through the custom namespace of the exported plugin', () => {
+      const linter = new Linter();
+      const config = defineConfig([
+        {
+          files: ['**/*.md'],
+          plugins: {
+            custommd: md,
+          },
+          extends: ['custommd/recommended'],
+          rules: {
+            'custommd/no-double-space': 'off',
+          },
+        },
+      ]);
+      const messages = linter.verify('12  34', config, { filename: 'test.md' });
+
+      assert.deepStrictEqual(messages, []);
     });
   });
 

--- a/packages/eslint-markdown/src/index.ts
+++ b/packages/eslint-markdown/src/index.ts
@@ -18,6 +18,7 @@ import pkg from '../package.json' with { type: 'json' };
 const plugin = {
   meta: {
     name: pkg.name as 'eslint-markdown' satisfies string,
+    namespace: 'md',
     version: pkg.version satisfies string,
   },
 

--- a/website/docs/get-started/configurations.md
+++ b/website/docs/get-started/configurations.md
@@ -257,6 +257,26 @@ export default defineConfig([
 
 :::
 
+### Custom Plugin Namespaces
+
+You can register `eslint-markdown` under a name other than `md`. When you use a string in `extends`, `defineConfig()` maps the inherited rule IDs to that name, so use the same prefix when overriding rules.
+
+```js [eslint.config.mjs]
+import { defineConfig } from 'eslint/config';
+import md from 'eslint-markdown';
+
+export default defineConfig([
+  {
+    files: ['**/*.md'],
+    plugins: { custommd: md },
+    extends: ['custommd/recommended'],
+    rules: {
+      'custommd/no-double-space': 'off',
+    },
+  },
+]);
+```
+
 ## Configurations
 
 ### `recommended`


### PR DESCRIPTION
Add `meta.namespace: 'md'` so `defineConfig()` correctly remaps inherited rule IDs when the plugin uses a custom namespace. This fixes overrides such as `'custommd/no-double-space': 'off'` after extending `custommd/recommended`.

Update regression tests to use the exported plugin, add a literal-type assertion for `meta.namespace`, and document custom namespace usage.