### PR TITLE
chore(release): bump package versions from `v0.14.1` to `v0.15.0` (`minor`)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "npm-eslint-markdown",
-  "version": "0.14.1",
+  "version": "0.15.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "npm-eslint-markdown",
-      "version": "0.14.1",
+      "version": "0.15.0",
       "workspaces": [
         "packages/*",
         "website"
@@ -10401,7 +10401,7 @@
       }
     },
     "packages/eslint-markdown": {
-      "version": "0.14.1",
+      "version": "0.15.0",
       "license": "MIT",
       "dependencies": {
         "micromark-util-normalize-identifier": "^2.0.1",
@@ -10443,7 +10443,7 @@
         "@eslint/config-inspector": "^3.4.0",
         "@shikijs/transformers": "^3.20.0",
         "@shikijs/vitepress-twoslash": "^3.20.0",
-        "eslint-markdown": "^0.14.1",
+        "eslint-markdown": "^0.15.0",
         "twoslash-eslint": "^0.3.4",
         "vitepress": "2.0.0-alpha.17",
         "vitepress-plugin-group-icons": "^1.7.6"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "npm-eslint-markdown",
-  "version": "0.14.1",
+  "version": "0.15.0",
   "type": "module",
   "packageManager": "npm@10.9.2",
   "engines": {

--- a/packages/eslint-markdown/package.json
+++ b/packages/eslint-markdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-markdown",
-  "version": "0.14.1",
+  "version": "0.15.0",
   "type": "module",
   "sideEffects": false,
   "description": "Lint your Markdown with ESLint. Additional rules for use with `@eslint/markdown`.🛠️",

--- a/website/package.json
+++ b/website/package.json
@@ -16,7 +16,7 @@
     "@eslint/config-inspector": "^3.4.0",
     "@shikijs/transformers": "^3.20.0",
     "@shikijs/vitepress-twoslash": "^3.20.0",
-    "eslint-markdown": "^0.14.1",
+    "eslint-markdown": "^0.15.0",
     "twoslash-eslint": "^0.3.4",
     "vitepress": "2.0.0-alpha.17",
     "vitepress-plugin-group-icons": "^1.7.6"


### PR DESCRIPTION
## Release Information: `v0.15.0`

New release of `lumirlumir/npm-eslint-markdown` has arrived! :tada:

This PR bumps the package versions from `v0.14.1` to `v0.15.0` (`minor`).

See [Actions](https://github.com/lumirlumir/npm-eslint-markdown/actions/runs/34238996553) for more details.

| Info        | Value                      |
| ----------- | -------------------------- |
| Repository  | `lumirlumir/npm-eslint-markdown` |
| SEMVER      | `minor`     |
| Pre ID      | `canary`      |
| Short SHA   | b84b20e       |
| Old Version | `v0.14.1`  |
| New Version | `v0.15.0`  |

<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
### :boom: BREAKING CHANGES
* feat(eslint-markdown)!: move `@eslint/markdown` to `peerDependencies`, drop support `@eslint/markdown` v7, support `@eslint/markdown` v8, and require the stable ESLint `^9.39.0 || ^10.0.0` peer dependency by @lumirlumir in https://github.com/lumirlumir/npm-eslint-markdown/pull/481
### :sparkles: Features
* feat(eslint-markdown): add `skipMath` option to `no-git-conflict-marker` by @vhmns14 in https://github.com/lumirlumir/npm-eslint-markdown/pull/691
### :bug: Bug Fixes
* fix(eslint-markdown): narrow `consistent-code-style` error ranges for the `style` message by @tooth-is-silver in https://github.com/lumirlumir/npm-eslint-markdown/pull/675
* fix(eslint-markdown): support custom namespaces in extended configs by @lumirlumir in https://github.com/lumirlumir/npm-eslint-markdown/pull/696
### :arrow_up: Dependency Updates
* chore(deps-dev): bump editorconfig-checker from 6.1.1 to 6.2.0 in the dev-dependencies group across 1 directory by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-markdown/pull/677
* chore(deps-dev): bump the dev-dependencies group across 2 directories with 1 update by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-markdown/pull/680
* chore(deps-dev): bump the vitest group across 1 directory with 2 updates by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-markdown/pull/684

## New Contributors
* @vhmns14 made their first contribution in https://github.com/lumirlumir/npm-eslint-markdown/pull/691

**Full Changelog**: https://github.com/lumirlumir/npm-eslint-markdown/compare/v0.14.1...v0.15.0