### PR TITLE
feat(eslint-markdown): detect trailing slashes before Unicode queries and fragments in `no-url-trailing-slash`

### DIFF
--- a/packages/eslint-markdown/src/rules/no-url-trailing-slash.test.ts
+++ b/packages/eslint-markdown/src/rules/no-url-trailing-slash.test.ts
@@ -35,6 +35,9 @@ ruleTester('no-url-trailing-slash', rule, {
     '[](https://example.com?query=string#)',
     '[](https://example.com/path/to/resource?query=string#)',
     '[](https://example.com/path/to/resource?query=string#fragment)',
+    '[](https://example.com?q=한글/)',
+    '[](https://example.com#한글/)',
+    '[](https://example.com/path?q=한글#제목)',
     '<https://example.com>',
     {
       code: 'https://example.com',
@@ -233,6 +236,45 @@ ruleTester('no-url-trailing-slash', rule, {
       ],
     },
     {
+      name: 'A trailing slash before a Unicode query string should be reported',
+      code: '[](https://example.com/?q=한글)',
+      errors: [
+        {
+          messageId: 'noUrlTrailingSlash',
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 30,
+        },
+      ],
+    },
+    {
+      name: 'A trailing slash before a Unicode fragment should be reported',
+      code: '[](https://example.com/#한글)',
+      errors: [
+        {
+          messageId: 'noUrlTrailingSlash',
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 28,
+        },
+      ],
+    },
+    {
+      name: 'A trailing path slash before a Unicode query and fragment should be reported',
+      code: '[](https://example.com/path/?q=한글#제목)',
+      errors: [
+        {
+          messageId: 'noUrlTrailingSlash',
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 38,
+        },
+      ],
+    },
+    {
       code: '<https://example.com/>',
       errors: [
         {
@@ -296,6 +338,19 @@ ruleTester('no-url-trailing-slash', rule, {
           column: 4,
           endLine: 1,
           endColumn: 31,
+        },
+      ],
+    },
+    {
+      name: 'An HTML link with a trailing slash before a Unicode query and fragment should be reported',
+      code: '<a href="https://example.com/?q=한글#제목">text</a>',
+      errors: [
+        {
+          messageId: 'noUrlTrailingSlash',
+          line: 1,
+          column: 4,
+          endLine: 1,
+          endColumn: 39,
         },
       ],
     },

--- a/packages/eslint-markdown/src/rules/no-url-trailing-slash.ts
+++ b/packages/eslint-markdown/src/rules/no-url-trailing-slash.ts
@@ -58,7 +58,7 @@ function hasTrailingSlash(url: string): boolean {
      *     -------------------------------------------------^
      */
     if (hash) {
-      urlWithoutSearchAndHash = urlWithoutSearchAndHash.slice(0, url.indexOf(hash));
+      urlWithoutSearchAndHash = urlWithoutSearchAndHash.slice(0, url.indexOf('#'));
     } else if (urlWithoutSearchAndHash.endsWith('#')) {
       urlWithoutSearchAndHash = urlWithoutSearchAndHash.slice(0, -1);
     }
@@ -76,7 +76,7 @@ function hasTrailingSlash(url: string): boolean {
      *     ------------------------------------^
      */
     if (search) {
-      urlWithoutSearchAndHash = urlWithoutSearchAndHash.slice(0, url.indexOf(search));
+      urlWithoutSearchAndHash = urlWithoutSearchAndHash.slice(0, url.indexOf('?'));
     } else if (urlWithoutSearchAndHash.endsWith('?')) {
       urlWithoutSearchAndHash = urlWithoutSearchAndHash.slice(0, -1);
     }


### PR DESCRIPTION
This pull request enhances the `no-url-trailing-slash` ESLint rule by improving its handling of URLs with Unicode characters in query strings and fragments. It adds comprehensive test coverage for these cases and fixes how the rule detects and processes trailing slashes before query strings and fragments.

**Testing improvements for Unicode in URLs:**

* Added new valid test cases with Unicode characters in query strings and fragments to ensure the rule does not incorrectly flag them.
* Added new invalid test cases that verify the rule correctly reports trailing slashes before Unicode query strings and fragments, including Markdown and HTML links. [[1]](diffhunk://#diff-30ba1669a4cb8f5ab1093876145fb6cfc58c0d46f5d7ba3b48ecd88bf71d2271R238-R276) [[2]](diffhunk://#diff-30ba1669a4cb8f5ab1093876145fb6cfc58c0d46f5d7ba3b48ecd88bf71d2271R344-R356)

**Bug fixes in trailing slash detection:**

* Updated the logic in `hasTrailingSlash` to use the actual `#` and `?` characters as delimiters, rather than relying on the possibly-encoded `hash` and `search` values, ensuring correct detection even with Unicode. [[1]](diffhunk://#diff-3b6611a918d726867ad44204bac2d75930f3e285be89140d161433687714559aL61-R61) [[2]](diffhunk://#diff-3b6611a918d726867ad44204bac2d75930f3e285be89140d161433687714559aL79-R79)