### PR TITLE
test(eslint-markdown): add additional test cases for `no-url-trailing-slash` rule

### DIFF
--- a/packages/eslint-markdown/src/rules/no-url-trailing-slash.test.ts
+++ b/packages/eslint-markdown/src/rules/no-url-trailing-slash.test.ts
@@ -32,6 +32,15 @@ ruleTester('no-url-trailing-slash', rule, {
     '[](https://example.com?query=string/)',
     '[](https://example.com#?)',
     '[](https://example.com?#)',
+    '[](127.0.0.1:5173/#/)',
+    '[](/#/)',
+    '[](/#/?)',
+    '[](/#/users?page=2)',
+    '[](/users?page=2)',
+    '[](http://127.0.0.1:5173/users?page=2)',
+    '[](http://127.0.0.1:5173#/)',
+    '[](http://127.0.0.1:5173#/?)',
+    '[](http://127.0.0.1:5173#/users?page=2)',
     '[](https://example.com?query=string#)',
     '[](https://example.com/path/to/resource?query=string#)',
     '[](https://example.com/path/to/resource?query=string#fragment)',
@@ -232,6 +241,42 @@ ruleTester('no-url-trailing-slash', rule, {
           column: 1,
           endLine: 1,
           endColumn: 64,
+        },
+      ],
+    },
+    {
+      code: '[](http://127.0.0.1:5173/#/)',
+      errors: [
+        {
+          messageId: 'noUrlTrailingSlash',
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 29,
+        },
+      ],
+    },
+    {
+      code: '[](http://127.0.0.1:5173/#/?)',
+      errors: [
+        {
+          messageId: 'noUrlTrailingSlash',
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 30,
+        },
+      ],
+    },
+    {
+      code: '[](http://127.0.0.1:5173/#/users?page=2)',
+      errors: [
+        {
+          messageId: 'noUrlTrailingSlash',
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 41,
         },
       ],
     },


### PR DESCRIPTION
This pull request expands the test coverage for the `no-url-trailing-slash` ESLint rule in the `packages/eslint-markdown` package. The main focus is on handling URLs with hash fragments and query parameters, particularly for URLs resembling local development environments. The changes ensure that the rule correctly identifies and reports trailing slashes in these new URL patterns.

Test coverage improvements:

* Added new valid test cases to `no-url-trailing-slash.test.ts` for URLs with hash fragments, query parameters, and local addresses (e.g., `127.0.0.1:5173/#/`, `/users?page=2`, etc.), ensuring the rule does not incorrectly flag these as violations.
* Added new invalid test cases for URLs with trailing slashes after hash fragments and query parameters (e.g., `http://127.0.0.1:5173/#/`, `http://127.0.0.1:5173/#/users?page=2`), verifying that the rule reports these patterns as expected.