### PR TITLE
docs(eslint-markdown): clarify `skipMath` applies to all math blocks

### DIFF
--- a/packages/eslint-markdown/src/rules/no-git-conflict-marker.ts
+++ b/packages/eslint-markdown/src/rules/no-git-conflict-marker.ts
@@ -26,7 +26,7 @@ type RuleOptions = [
      */
     skipCode: boolean | string[];
     /**
-     * `true` allows Git conflict markers in math blocks.
+     * `true` allows Git conflict markers in all math blocks.
      * @default true
      */
     skipMath: boolean;

--- a/website/docs/rules/no-git-conflict-marker.md
+++ b/website/docs/rules/no-git-conflict-marker.md
@@ -200,7 +200,7 @@ Examples of **correct** code for this rule:
 
 > Type: `boolean` / Default: `true`
 
-`true` allows Git conflict markers in math blocks.
+`true` allows Git conflict markers in all math blocks.
 
 ::: tip NOTE
 This option requires enabling math parsing with [`languageOptions: { math: true }`](https://github.com/eslint/markdown#enabling-math-latex-in-both-commonmark-and-gfm).


### PR DESCRIPTION
This pull request makes a minor clarification to the documentation and type comments for the `skipMath` option in the `no-git-conflict-marker` rule. The change specifies that enabling `skipMath` allows Git conflict markers in all math blocks, not just some.

- Documentation and type comment update:
  * Clarified that setting `skipMath: true` allows Git conflict markers in all math blocks in both the code comment in `no-git-conflict-marker.ts` and the corresponding documentation in `no-git-conflict-marker.md`. [[1]](diffhunk://#diff-cc15f8860a0bd006327f8132c273eb13d0cb3e0d1e1d07c08ca83034f8db1194L29-R29) [[2]](diffhunk://#diff-5e6b1687e0b2cf50aed9dd8bc06805979e4a827b46b4dc3f1c47d33ed2a4e252L203-R203)