### PR TITLE
test(eslint-markdown): add missing rule type checks

### DIFF
--- a/packages/eslint-markdown/src/index.test-d.ts
+++ b/packages/eslint-markdown/src/index.test-d.ts
@@ -51,12 +51,14 @@ type RuleName = keyof typeof plugin.rules;
 // @ts-expect-error -- Rule message IDs should remain specific to each rule.
 plugin.rules['no-emoji'].meta.messages.unknownMessage;
 
+'allow-heading' satisfies RuleName;
 'allow-image-url' satisfies RuleName;
 'allow-link-url' satisfies RuleName;
 'code-lang-shorthand' satisfies RuleName;
 'consistent-code-style' satisfies RuleName;
 'consistent-delete-style' satisfies RuleName;
 'consistent-emphasis-style' satisfies RuleName;
+'consistent-inline-code-style' satisfies RuleName;
 'consistent-strong-style' satisfies RuleName;
 'consistent-thematic-break-style' satisfies RuleName;
 'consistent-unordered-list-style' satisfies RuleName;
@@ -70,7 +72,9 @@ plugin.rules['no-emoji'].meta.messages.unknownMessage;
 'no-irregular-dash' satisfies RuleName;
 'no-irregular-whitespace' satisfies RuleName;
 'no-tab' satisfies RuleName;
+'no-trailing-heading-punctuation' satisfies RuleName;
 'no-url-trailing-slash' satisfies RuleName;
+'require-heading-id' satisfies RuleName;
 'require-image-title' satisfies RuleName;
 'require-link-title' satisfies RuleName;
 
@@ -90,12 +94,14 @@ plugin.configs.all.rules satisfies Linter.RulesRecord;
 
 type AllConfigRuleName = keyof typeof plugin.configs.all.rules;
 
+'md/allow-heading' satisfies AllConfigRuleName;
 'md/allow-image-url' satisfies AllConfigRuleName;
 'md/allow-link-url' satisfies AllConfigRuleName;
 'md/code-lang-shorthand' satisfies AllConfigRuleName;
 'md/consistent-code-style' satisfies AllConfigRuleName;
 'md/consistent-delete-style' satisfies AllConfigRuleName;
 'md/consistent-emphasis-style' satisfies AllConfigRuleName;
+'md/consistent-inline-code-style' satisfies AllConfigRuleName;
 'md/consistent-strong-style' satisfies AllConfigRuleName;
 'md/consistent-thematic-break-style' satisfies AllConfigRuleName;
 'md/consistent-unordered-list-style' satisfies AllConfigRuleName;
@@ -109,7 +115,9 @@ type AllConfigRuleName = keyof typeof plugin.configs.all.rules;
 'md/no-irregular-dash' satisfies AllConfigRuleName;
 'md/no-irregular-whitespace' satisfies AllConfigRuleName;
 'md/no-tab' satisfies AllConfigRuleName;
+'md/no-trailing-heading-punctuation' satisfies AllConfigRuleName;
 'md/no-url-trailing-slash' satisfies AllConfigRuleName;
+'md/require-heading-id' satisfies AllConfigRuleName;
 'md/require-image-title' satisfies AllConfigRuleName;
 'md/require-link-title' satisfies AllConfigRuleName;
 
@@ -144,11 +152,13 @@ type StylisticConfigRuleName = keyof typeof plugin.configs.stylistic.rules;
 'md/consistent-code-style' satisfies StylisticConfigRuleName;
 'md/consistent-delete-style' satisfies StylisticConfigRuleName;
 'md/consistent-emphasis-style' satisfies StylisticConfigRuleName;
+'md/consistent-inline-code-style' satisfies StylisticConfigRuleName;
 'md/consistent-strong-style' satisfies StylisticConfigRuleName;
 'md/consistent-thematic-break-style' satisfies StylisticConfigRuleName;
 'md/consistent-unordered-list-style' satisfies StylisticConfigRuleName;
 'md/no-consecutive-blank-line' satisfies StylisticConfigRuleName;
 'md/no-tab' satisfies StylisticConfigRuleName;
+'md/no-trailing-heading-punctuation' satisfies StylisticConfigRuleName;
 
 // #endregion configs
 // --------------------------------------------------------------------------------


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
  Be sure to check our contributing guidelines in the `README.md` or `CONTRIBUTING.md` before opening a pull request.
-->

## Summary

`src/index.test-d.ts` asserts that each rule name is assignable to the exported types, but ten assertions were missing, covering four rules. The gap is silent: a rule can be added to `src/rules/index.ts` and to a config without any type check covering it.

This adds the missing assertions so every rule and every config entry is covered.

<!--
  Explain the motivation for making this change. What existing problem does the pull request solve?
-->

## Details

Missing from `RuleName` and `AllConfigRuleName`:
- `allow-heading`
- `consistent-inline-code-style`
- `no-trailing-heading-punctuation`
- `require-heading-id`

Missing from `StylisticConfigRuleName`:
- `consistent-inline-code-style`
- `no-trailing-heading-punctuation`

`RecommendedConfigRuleName` was already complete. Entries keep the existing alphabetical order. No rule, config, or runtime code changes.

<!--
  Explain the details you made on this pull request.
  The more detailed it is, the more likely it will be approved.
-->

## How did you test this change?

- `npm run lint`
- `npm run test`

All 2,265 tests passed.

I also renamed a rule in `src/rules/index.ts` to confirm the added assertions fail `npm run test:types` as expected.

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots or videos.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

## Resolved Issues

N/A
<!--
  If you fixed problems in issues, write down the numbers of issues.
  Example: #1, #2, ...
-->

## Checklist

- [x] I have read the [**code of conduct**](https://github.com/lumirlumir/.github/blob/main/CODE_OF_CONDUCT.md) and **contributing guidelines** in the repository root.
