### PR TITLE
chore(release): bump package versions from `v0.15.0` to `v0.16.0` (`minor`)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "npm-eslint-markdown",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "npm-eslint-markdown",
-      "version": "0.15.0",
+      "version": "0.16.0",
       "workspaces": [
         "packages/*",
         "website"
@@ -10401,7 +10401,7 @@
       }
     },
     "packages/eslint-markdown": {
-      "version": "0.15.0",
+      "version": "0.16.0",
       "license": "MIT",
       "dependencies": {
         "micromark-util-normalize-identifier": "^2.0.1",
@@ -10443,7 +10443,7 @@
         "@eslint/config-inspector": "^3.4.0",
         "@shikijs/transformers": "^3.20.0",
         "@shikijs/vitepress-twoslash": "^3.20.0",
-        "eslint-markdown": "^0.15.0",
+        "eslint-markdown": "^0.16.0",
         "twoslash-eslint": "^0.3.4",
         "vitepress": "2.0.0-alpha.17",
         "vitepress-plugin-group-icons": "^1.7.6"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "npm-eslint-markdown",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "type": "module",
   "packageManager": "npm@10.9.2",
   "engines": {

--- a/packages/eslint-markdown/package.json
+++ b/packages/eslint-markdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-markdown",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "type": "module",
   "sideEffects": false,
   "description": "Lint your Markdown with ESLint. Additional rules for use with `@eslint/markdown`.🛠️",

--- a/website/package.json
+++ b/website/package.json
@@ -16,7 +16,7 @@
     "@eslint/config-inspector": "^3.4.0",
     "@shikijs/transformers": "^3.20.0",
     "@shikijs/vitepress-twoslash": "^3.20.0",
-    "eslint-markdown": "^0.15.0",
+    "eslint-markdown": "^0.16.0",
     "twoslash-eslint": "^0.3.4",
     "vitepress": "2.0.0-alpha.17",
     "vitepress-plugin-group-icons": "^1.7.6"


### PR DESCRIPTION
## Release Information: `v0.16.0`

New release of `lumirlumir/npm-eslint-markdown` has arrived! :tada:

This PR bumps the package versions from `v0.15.0` to `v0.16.0` (`minor`).

See [Actions](https://github.com/lumirlumir/npm-eslint-markdown/actions/runs/34687459891) for more details.

| Info        | Value                      |
| ----------- | -------------------------- |
| Repository  | `lumirlumir/npm-eslint-markdown` |
| SEMVER      | `minor`     |
| Pre ID      | `canary`      |
| Short SHA   | b294788       |
| Old Version | `v0.15.0`  |
| New Version | `v0.16.0`  |

<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
### :boom: BREAKING CHANGES
* feat(eslint-markdown)!: add `consistent-heading-style` rule by @tooth-is-silver in https://github.com/lumirlumir/npm-eslint-markdown/pull/647
### :sparkles: Features
* feat(eslint-markdown): detect trailing slashes before Unicode queries and fragments in `no-url-trailing-slash` by @lumirlumir in https://github.com/lumirlumir/npm-eslint-markdown/pull/698
* feat(eslint-markdown): add `skipMath` and `skipInlineMath` options to `no-irregular-whitespace` by @vhmns14 in https://github.com/lumirlumir/npm-eslint-markdown/pull/693
### :memo: Documentation
* docs(eslint-markdown): clarify `skipMath` applies to all math blocks by @lumirlumir in https://github.com/lumirlumir/npm-eslint-markdown/pull/700
### :test_tube: Tests
* test(eslint-markdown): add additional test cases for `no-url-trailing-slash` rule by @lumirlumir in https://github.com/lumirlumir/npm-eslint-markdown/pull/699
* test(eslint-markdown): add missing rule type checks by @tooth-is-silver in https://github.com/lumirlumir/npm-eslint-markdown/pull/701
### :arrow_up: Dependency Updates
* chore(deps-dev): bump browserslist from 4.28.2 to 4.28.9 by @dependabot[bot] in https://github.com/lumirlumir/npm-eslint-markdown/pull/702


**Full Changelog**: https://github.com/lumirlumir/npm-eslint-markdown/compare/v0.15.0...v0.16.0