### PR TITLE
refactor(eslint-markdown): use named exports for core utilities

### DIFF
--- a/packages/eslint-markdown/src/core/utils/escape-string-regexp.test.ts
+++ b/packages/eslint-markdown/src/core/utils/escape-string-regexp.test.ts
@@ -32,7 +32,7 @@
 // --------------------------------------------------------------------------------
 
 import { assert, describe, it } from 'vitest';
-import escapeStringRegexp from './escape-string-regexp.js';
+import { escapeStringRegexp } from './escape-string-regexp.js';
 
 // --------------------------------------------------------------------------------
 // Test

--- a/packages/eslint-markdown/src/core/utils/escape-string-regexp.ts
+++ b/packages/eslint-markdown/src/core/utils/escape-string-regexp.ts
@@ -40,7 +40,7 @@
  * @returns An escaped string.
  * @example
  * ```js
- * import escapeStringRegexp from 'path/to/escape-string-regexp.js';
+ * import { escapeStringRegexp } from 'path/to/escape-string-regexp.js';
  *
  * const escapedString = escapeStringRegexp('How much $ for a 🦄?');
  * //=> 'How much \\$ for a 🦄\\?'
@@ -48,7 +48,7 @@
  * new RegExp(escapedString);
  * ```
  */
-export default function escapeStringRegexp(string: string): string {
+export function escapeStringRegexp(string: string): string {
   // Escape characters with special meaning either inside or outside character sets.
   // Use a simple backslash escape when it's always valid, and a `\xnn` escape
   // when the simpler form would be disallowed by Unicode patterns' stricter grammar.

--- a/packages/eslint-markdown/src/core/utils/html.test.ts
+++ b/packages/eslint-markdown/src/core/utils/html.test.ts
@@ -7,7 +7,7 @@
 // --------------------------------------------------------------------------------
 
 import { assert, describe, it } from 'vitest';
-import getElementsByTagName from './html.js';
+import { getElementsByTagName } from './html.js';
 
 // --------------------------------------------------------------------------------
 // Helper

--- a/packages/eslint-markdown/src/core/utils/html.ts
+++ b/packages/eslint-markdown/src/core/utils/html.ts
@@ -19,7 +19,7 @@ import type { DefaultTreeAdapterTypes } from 'parse5';
  * @param tagName The tag name to search for (case-insensitive).
  * @returns Matched elements.
  */
-export default function getElementsByTagName(
+export function getElementsByTagName(
   html: string,
   tagName: string,
 ): (DefaultTreeAdapterTypes.Element | DefaultTreeAdapterTypes.Template)[] {

--- a/packages/eslint-markdown/src/core/utils/index.ts
+++ b/packages/eslint-markdown/src/core/utils/index.ts
@@ -1,15 +1,6 @@
-import escapeStringRegexp from './escape-string-regexp.js';
-import getElementsByTagName from './html.js';
-import isBlankLine from './is-blank-line.js';
-import normalizeRegexPattern from './normalize-regex-pattern.js';
-import SkipRanges from './skip-ranges.js';
-import testRegexStateless from './test-regex-stateless.js';
-
-export {
-  escapeStringRegexp,
-  getElementsByTagName,
-  isBlankLine,
-  normalizeRegexPattern,
-  SkipRanges,
-  testRegexStateless,
-};
+export * from './escape-string-regexp.js';
+export * from './html.js';
+export * from './is-blank-line.js';
+export * from './normalize-regex-pattern.js';
+export * from './skip-ranges.js';
+export * from './test-regex-stateless.js';

--- a/packages/eslint-markdown/src/core/utils/is-blank-line.test.ts
+++ b/packages/eslint-markdown/src/core/utils/is-blank-line.test.ts
@@ -7,7 +7,7 @@
 // --------------------------------------------------------------------------------
 
 import { assert, describe, it } from 'vitest';
-import isBlankLine from './is-blank-line.js';
+import { isBlankLine } from './is-blank-line.js';
 
 // --------------------------------------------------------------------------------
 // Test

--- a/packages/eslint-markdown/src/core/utils/is-blank-line.ts
+++ b/packages/eslint-markdown/src/core/utils/is-blank-line.ts
@@ -21,7 +21,7 @@ const blockquoteChar = '>';
  * @param blockquoteDepth The depth of blockquotes. Default is `-1`.
  * @returns `true` if the line is blank. `false` otherwise.
  */
-export default function isBlankLine(str: string, blockquoteDepth = -1): boolean {
+export function isBlankLine(str: string, blockquoteDepth = -1): boolean {
   // `.length` is cached for performance.
   const strLength = str.length;
   let remainingBlockquotes = blockquoteDepth + 1;

--- a/packages/eslint-markdown/src/core/utils/normalize-regex-pattern.test.ts
+++ b/packages/eslint-markdown/src/core/utils/normalize-regex-pattern.test.ts
@@ -7,7 +7,7 @@
 // --------------------------------------------------------------------------------
 
 import { assert, describe, it } from 'vitest';
-import normalizeRegexPattern from './normalize-regex-pattern.js';
+import { normalizeRegexPattern } from './normalize-regex-pattern.js';
 
 // --------------------------------------------------------------------------------
 // Test

--- a/packages/eslint-markdown/src/core/utils/normalize-regex-pattern.ts
+++ b/packages/eslint-markdown/src/core/utils/normalize-regex-pattern.ts
@@ -13,6 +13,6 @@
  * @param pattern `RegExp` or string pattern to normalize.
  * @returns The normalized `RegExp`.
  */
-export default function normalizeRegexPattern(pattern: RegExp | string): RegExp {
+export function normalizeRegexPattern(pattern: RegExp | string): RegExp {
   return typeof pattern === 'string' ? new RegExp(pattern, 'u') : pattern;
 }

--- a/packages/eslint-markdown/src/core/utils/skip-ranges.test.ts
+++ b/packages/eslint-markdown/src/core/utils/skip-ranges.test.ts
@@ -11,7 +11,7 @@
 // --------------------------------------------------------------------------------
 
 import { assert, describe, it } from 'vitest';
-import SkipRanges from './skip-ranges.js';
+import { SkipRanges } from './skip-ranges.js';
 
 // --------------------------------------------------------------------------------
 // Test

--- a/packages/eslint-markdown/src/core/utils/skip-ranges.ts
+++ b/packages/eslint-markdown/src/core/utils/skip-ranges.ts
@@ -21,7 +21,7 @@ type SourceRange = AST.Range;
 /**
  * Class to manage skip ranges.
  */
-export default class SkipRanges {
+export class SkipRanges {
   // ------------------------------------------------------------------------------
   // Private Property
   // ------------------------------------------------------------------------------

--- a/packages/eslint-markdown/src/core/utils/test-regex-stateless.test.ts
+++ b/packages/eslint-markdown/src/core/utils/test-regex-stateless.test.ts
@@ -7,7 +7,7 @@
 // --------------------------------------------------------------------------------
 
 import { assert, describe, it } from 'vitest';
-import testRegexStateless from './test-regex-stateless.js';
+import { testRegexStateless } from './test-regex-stateless.js';
 
 // --------------------------------------------------------------------------------
 // Test

--- a/packages/eslint-markdown/src/core/utils/test-regex-stateless.ts
+++ b/packages/eslint-markdown/src/core/utils/test-regex-stateless.ts
@@ -18,7 +18,7 @@ const statefulRegexFlagRegex = /[gy]/u;
  * @param text Text to test.
  * @returns Whether the regex matches the text.
  */
-export default function testRegexStateless(regex: RegExp, text: string) {
+export function testRegexStateless(regex: RegExp, text: string) {
   return statefulRegexFlagRegex.test(regex.flags)
     ? new RegExp(regex).test(text)
     : regex.test(text);


### PR DESCRIPTION
## Summary

- Convert all five core utility functions and the `SkipRanges` class to named exports.
- Replace mixed imports and exports in the utility barrel with `export * from` declarations.
- Update direct imports in existing tests and the JSDoc example.

## Scope

- `packages/eslint-markdown/src/core/utils/`

## Validation

Results from the implementation step; no additional validation was run when preparing this PR, as requested:

- `npm run test`: passed type checks and all 2,678 tests across 37 test files.
- `npm run build`: passed package and website builds.
- `npm run lint`: failed only on eight existing indentation errors in the untracked local `todo.txt`; ESLint, Prettier, and Markdownlint passed.

## Notes

- Existing named imports through the utility barrel remain compatible.
- The local `todo.txt` is not included in this PR.