### PR TITLE
feat(eslint-markdown): add math skip options to `no-irregular-dash`

### DIFF
--- a/packages/eslint-markdown/src/rules/no-irregular-dash.test.ts
+++ b/packages/eslint-markdown/src/rules/no-irregular-dash.test.ts
@@ -45,6 +45,22 @@ console.log(\u2014'Hello World');
 
 \`console.log(\u2014'Hello World')\``,
     },
+    {
+      name: 'Irregular dash in a math block should be skipped by default',
+      code: `$$
+x\u2212y
+$$`,
+      languageOptions: {
+        math: true,
+      },
+    },
+    {
+      name: 'Irregular dash in inline math should be skipped by default',
+      code: '$x\u2212y$',
+      languageOptions: {
+        math: true,
+      },
+    },
 
     // Options
     {
@@ -108,6 +124,44 @@ console.log(\u2014'Hello World');
           override: { '\u2014': '---' },
         },
       ],
+    },
+    {
+      name: '`skipMath: true` should skip an irregular dash in a math block',
+      code: `$$
+x\u2212y
+$$`,
+      options: [
+        {
+          skipMath: true,
+        },
+      ],
+      languageOptions: {
+        math: true,
+      },
+    },
+    {
+      name: '`skipInlineMath: true` should skip an irregular dash in inline math',
+      code: '$x\u2212y$',
+      options: [
+        {
+          skipInlineMath: true,
+        },
+      ],
+      languageOptions: {
+        math: true,
+      },
+    },
+    {
+      name: '`allow` should permit an irregular dash outside math regions when math parsing is enabled',
+      code: 'Prose\u2013text',
+      options: [
+        {
+          allow: ['\u2013'],
+        },
+      ],
+      languageOptions: {
+        math: true,
+      },
     },
   ],
 
@@ -492,6 +546,208 @@ Foo-Bar
       options: [
         {
           override: { '\u2014': '--' },
+        },
+      ],
+    },
+    {
+      name: '`skipMath: false` should report an irregular dash in a math block',
+      code: `$$
+x\u2212y
+$$`,
+      output: `$$
+x-y
+$$`,
+      errors: [
+        {
+          messageId: 'noIrregularDash',
+          line: 2,
+          column: 2,
+          endLine: 2,
+          endColumn: 3,
+          data: {
+            irregularDash: 'U+2212',
+          },
+        },
+      ],
+      options: [
+        {
+          skipMath: false,
+        },
+      ],
+      languageOptions: {
+        math: true,
+      },
+    },
+    {
+      name: '`skipInlineMath: false` should report an irregular dash in inline math',
+      code: '$x\u2212y$',
+      output: '$x-y$',
+      errors: [
+        {
+          messageId: 'noIrregularDash',
+          line: 1,
+          column: 3,
+          endLine: 1,
+          endColumn: 4,
+          data: {
+            irregularDash: 'U+2212',
+          },
+        },
+      ],
+      options: [
+        {
+          skipInlineMath: false,
+        },
+      ],
+      languageOptions: {
+        math: true,
+      },
+    },
+    {
+      name: '`skipMath: true, skipInlineMath: false` should skip only the math block',
+      code: `$$
+x\u2212y
+$$
+
+$a\u2212b$`,
+      output: `$$
+x\u2212y
+$$
+
+$a-b$`,
+      errors: [
+        {
+          messageId: 'noIrregularDash',
+          line: 5,
+          column: 3,
+          endLine: 5,
+          endColumn: 4,
+          data: {
+            irregularDash: 'U+2212',
+          },
+        },
+      ],
+      options: [
+        {
+          skipMath: true,
+          skipInlineMath: false,
+        },
+      ],
+      languageOptions: {
+        math: true,
+      },
+    },
+    {
+      name: '`skipMath: false, skipInlineMath: true` should skip only inline math',
+      code: `$$
+x\u2212y
+$$
+
+$a\u2212b$`,
+      output: `$$
+x-y
+$$
+
+$a\u2212b$`,
+      errors: [
+        {
+          messageId: 'noIrregularDash',
+          line: 2,
+          column: 2,
+          endLine: 2,
+          endColumn: 3,
+          data: {
+            irregularDash: 'U+2212',
+          },
+        },
+      ],
+      options: [
+        {
+          skipMath: false,
+          skipInlineMath: true,
+        },
+      ],
+      languageOptions: {
+        math: true,
+      },
+    },
+    {
+      name: 'Irregular dash outside skipped math regions should be reported',
+      code: `Prose\u2212text
+
+$$
+x\u2212y
+$$
+
+$a\u2212b$`,
+      output: `Prose-text
+
+$$
+x\u2212y
+$$
+
+$a\u2212b$`,
+      errors: [
+        {
+          messageId: 'noIrregularDash',
+          line: 1,
+          column: 6,
+          endLine: 1,
+          endColumn: 7,
+          data: {
+            irregularDash: 'U+2212',
+          },
+        },
+      ],
+      languageOptions: {
+        math: true,
+      },
+    },
+    {
+      name: 'Math delimiters should not skip an irregular dash when math parsing is disabled',
+      code: `$$
+x\u2212y
+$$`,
+      output: `$$
+x-y
+$$`,
+      errors: [
+        {
+          messageId: 'noIrregularDash',
+          line: 2,
+          column: 2,
+          endLine: 2,
+          endColumn: 3,
+          data: {
+            irregularDash: 'U+2212',
+          },
+        },
+      ],
+      options: [
+        {
+          skipMath: true,
+        },
+      ],
+    },
+    {
+      name: 'Inline math delimiters should not skip an irregular dash when math parsing is disabled',
+      code: '$x\u2212y$',
+      output: '$x-y$',
+      errors: [
+        {
+          messageId: 'noIrregularDash',
+          line: 1,
+          column: 3,
+          endLine: 1,
+          endColumn: 4,
+          data: {
+            irregularDash: 'U+2212',
+          },
+        },
+      ],
+      options: [
+        {
+          skipInlineMath: true,
         },
       ],
     },

--- a/packages/eslint-markdown/src/rules/no-irregular-dash.ts
+++ b/packages/eslint-markdown/src/rules/no-irregular-dash.ts
@@ -42,6 +42,16 @@ type RuleOptions = [
      * @default true
      */
     skipInlineCode: boolean;
+    /**
+     * `true` allows irregular dashes in all math blocks.
+     * @default true
+     */
+    skipMath: boolean;
+    /**
+     * `true` allows irregular dashes in all inline math.
+     * @default true
+     */
+    skipInlineMath: boolean;
   },
 ];
 type MessageIds = 'noIrregularDash';
@@ -126,6 +136,12 @@ export default {
           skipInlineCode: {
             type: 'boolean',
           },
+          skipMath: {
+            type: 'boolean',
+          },
+          skipInlineMath: {
+            type: 'boolean',
+          },
         },
         additionalProperties: false,
       },
@@ -137,6 +153,8 @@ export default {
         override: {},
         skipCode: true,
         skipInlineCode: true,
+        skipMath: true,
+        skipInlineMath: true,
       },
     ],
 
@@ -151,7 +169,8 @@ export default {
 
   create(context) {
     const { sourceCode } = context;
-    const [{ allow, override, skipCode, skipInlineCode }] = context.options;
+    const [{ allow, override, skipCode, skipInlineCode, skipMath, skipInlineMath }] =
+      context.options;
 
     const skipRanges = new SkipRanges();
 
@@ -170,6 +189,14 @@ export default {
 
       inlineCode(node) {
         if (skipInlineCode) skipRanges.push(sourceCode.getRange(node)); // Store range information of `InlineCode`.
+      },
+
+      math(node) {
+        if (skipMath) skipRanges.push(sourceCode.getRange(node)); // Store range information of `Math`.
+      },
+
+      inlineMath(node) {
+        if (skipInlineMath) skipRanges.push(sourceCode.getRange(node)); // Store range information of `InlineMath`.
       },
 
       'root:exit'() {

--- a/website/docs/rules/no-irregular-dash.md
+++ b/website/docs/rules/no-irregular-dash.md
@@ -118,6 +118,24 @@ Examples of **incorrect** code for this rule:
 \u2011 - Non-Breaking Hyphen - <NBHY> `‑` <= Here
 ```
 
+#### With `{ skipMath: false }` Option
+
+```md eslint-check
+<!-- eslint md/no-irregular-dash: ['error', { skipMath: false }] -->
+
+$$
+\u2212 - Minus Sign - <MINUS> − <= Here
+$$
+```
+
+#### With `{ skipInlineMath: false }` Option
+
+```md eslint-check
+<!-- eslint md/no-irregular-dash: ['error', { skipInlineMath: false }] -->
+
+\u2212 - Minus Sign - <MINUS> $−$ <= Here
+```
+
 ### :white_check_mark: Correct
 
 Examples of **correct** code for this rule:
@@ -188,6 +206,24 @@ Examples of **correct** code for this rule:
 \u2011 - Non-Breaking Hyphen - <NBHY> `‑` <= Here
 ```
 
+#### With `{ skipMath: true }` Option
+
+```md eslint-check
+<!-- eslint md/no-irregular-dash: ['error', { skipMath: true }] -->
+
+$$
+\u2212 - Minus Sign - <MINUS> − <= Here
+$$
+```
+
+#### With `{ skipInlineMath: true }` Option
+
+```md eslint-check
+<!-- eslint md/no-irregular-dash: ['error', { skipInlineMath: true }] -->
+
+\u2212 - Minus Sign - <MINUS> $−$ <= Here
+```
+
 ## Options
 
 ```js
@@ -196,6 +232,8 @@ Examples of **correct** code for this rule:
   override: {},
   skipCode: true,
   skipInlineCode: true,
+  skipMath: true,
+  skipInlineMath: true,
 }]
 ```
 
@@ -241,6 +279,38 @@ If a dash stands alone on a line, the fixed line can be parsed differently. For 
 > Type: `boolean` / Default: `true`
 
 `true` allows irregular dashes in all inline code.
+
+### `skipMath`
+
+> Type: `boolean` / Default: `true`
+
+`true` allows irregular dashes in all math blocks.
+
+::: tip NOTE
+This option requires enabling math parsing with [`languageOptions: { math: true }`](https://github.com/eslint/markdown#enabling-math-latex-in-both-commonmark-and-gfm).
+:::
+
+### `skipInlineMath`
+
+> Type: `boolean` / Default: `true`
+
+`true` allows irregular dashes in all inline math.
+
+::: tip NOTE
+This option requires enabling math parsing with [`languageOptions: { math: true }`](https://github.com/eslint/markdown#enabling-math-latex-in-both-commonmark-and-gfm).
+:::
+
+::: warning Behavior change
+With math parsing enabled, irregular dashes inside math blocks and inline math are skipped by default. Set both options to `false` to preserve the previous behavior:
+
+```js
+'md/no-irregular-dash': ['error', {
+  skipMath: false,
+  skipInlineMath: false,
+}]
+```
+
+:::
 
 ## Fix
 


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
  Be sure to check our contributing guidelines in the `README.md` or `CONTRIBUTING.md` before opening a pull request.
-->
  
## Summary

Adds `skipMath` and `skipInlineMath` options to avoid reporting intentional irregular dashes in math regions.

## Details

Added `skipMath` and `skipInlineMath` options with default values of `true`.

Used `math` and `inlineMath` AST node ranges to exclude math regions while preserving the existing `allow` and autofix behavior.

Added tests for default and explicit options, independent option behavior, surrounding text, `allow`, and disabled math parsing.

Updated the rule documentation with examples, configuration requirements, and previous-behavior guidance.

## How did you test this change?

I implemented the rule based on the issue requirements and updated the documentation by referring to similar prior PRs. 

For the tests below, I tried to keep each case focused on a single behavior wherever possible. I would appreciate any feedback.

```
Valid:
- Irregular dash in a math block should be skipped by default
- Irregular dash in inline math should be skipped by default
- `skipMath: true` should skip an irregular dash in a math block
- `skipInlineMath: true` should skip an irregular dash in inline math
- `allow` should permit an irregular dash outside math regions when math parsing is enabled

Invalid:
- `skipMath: false` should report an irregular dash in a math block
- `skipInlineMath: false` should report an irregular dash in inline math
- `skipMath: true, skipInlineMath: false` should skip only the math block
- `skipMath: false, skipInlineMath: true` should skip only inline math
- Irregular dash outside skipped math regions should be reported
- Math delimiters should not skip an irregular dash when math parsing is disabled
- Inline math delimiters should not skip an irregular dash when math parsing is disabled
```

## Resolved Issues

Closes #687

## Checklist

- [x] I have read the [**code of conduct**](https://github.com/lumirlumir/.github/blob/main/CODE_OF_CONDUCT.md) and **contributing guidelines** in the repository root.
