### PR TITLE
docs(website): fix CommonJS configuration examples

### DIFF
--- a/website/docs/get-started/configurations.md
+++ b/website/docs/get-started/configurations.md
@@ -63,8 +63,8 @@ export default defineConfig([
 
 ```js [eslint.config.cjs]
 const { defineConfig } = require('eslint/config');
-const markdown = require('@eslint/markdown');
-const md = require('eslint-markdown'); // [!code ++]
+const markdown = require('@eslint/markdown').default;
+const md = require('eslint-markdown').default; // [!code ++]
 
 module.exports = defineConfig([
   {
@@ -129,8 +129,8 @@ export default defineConfig([
 
 ```js [eslint.config.cjs]
 const { defineConfig } = require('eslint/config');
-const markdown = require('@eslint/markdown');
-const md = require('eslint-markdown'); // [!code ++]
+const markdown = require('@eslint/markdown').default;
+const md = require('eslint-markdown').default; // [!code ++]
 
 module.exports = defineConfig([
   markdown.configs.recommended,
@@ -183,7 +183,7 @@ export default defineConfig([
 
 ```js [eslint.config.cjs]
 const { defineConfig } = require('eslint/config');
-const md = require('eslint-markdown'); // [!code ++]
+const md = require('eslint-markdown').default; // [!code ++]
 
 module.exports = defineConfig([
   {
@@ -233,7 +233,7 @@ export default defineConfig([
 
 ```js [eslint.config.cjs]
 const { defineConfig } = require('eslint/config');
-const md = require('eslint-markdown'); // [!code ++]
+const md = require('eslint-markdown').default; // [!code ++]
 
 module.exports = defineConfig([
   md.configs.recommended, // [!code ++]
@@ -314,7 +314,7 @@ export default defineConfig([
 
 ```js [eslint.config.cjs]
 const { defineConfig } = require('eslint/config');
-const md = require('eslint-markdown');
+const md = require('eslint-markdown').default;
 
 module.exports = defineConfig([
   {
@@ -366,7 +366,7 @@ export default defineConfig([
 
 ```js [eslint.config.cjs]
 const { defineConfig } = require('eslint/config');
-const md = require('eslint-markdown');
+const md = require('eslint-markdown').default;
 
 module.exports = defineConfig([
   md.configs.recommended,
@@ -429,7 +429,7 @@ export default defineConfig([
 
 ```js [eslint.config.cjs]
 const { defineConfig } = require('eslint/config');
-const md = require('eslint-markdown');
+const md = require('eslint-markdown').default;
 
 module.exports = defineConfig([
   {
@@ -481,7 +481,7 @@ export default defineConfig([
 
 ```js [eslint.config.cjs]
 const { defineConfig } = require('eslint/config');
-const md = require('eslint-markdown');
+const md = require('eslint-markdown').default;
 
 module.exports = defineConfig([
   md.configs.stylistic,
@@ -543,7 +543,7 @@ export default defineConfig([
 
 ```js [eslint.config.cjs]
 const { defineConfig } = require('eslint/config');
-const md = require('eslint-markdown');
+const md = require('eslint-markdown').default;
 
 module.exports = defineConfig([
   {
@@ -604,7 +604,7 @@ export default defineConfig([
 
 ```js [eslint.config.cjs]
 const { defineConfig } = require('eslint/config');
-const md = require('eslint-markdown');
+const md = require('eslint-markdown').default;
 
 module.exports = defineConfig([
   md.configs.base,
@@ -676,7 +676,7 @@ export default defineConfig([
 
 ```js [eslint.config.cjs]
 const { defineConfig } = require('eslint/config');
-const md = require('eslint-markdown');
+const md = require('eslint-markdown').default;
 
 module.exports = defineConfig([
   {
@@ -717,7 +717,7 @@ export default defineConfig([
 
 ```js [eslint.config.cjs]
 const { defineConfig } = require('eslint/config');
-const md = require('eslint-markdown');
+const md = require('eslint-markdown').default;
 
 module.exports = defineConfig([
   md.configs.all,


### PR DESCRIPTION
<img width="991" height="94" alt="image" src="https://github.com/user-attachments/assets/0a670540-6c87-462f-8702-597b38b236d9" />

## Summary

Since this is a small documentation fix, I'm opening a PR directly without a separate issue.

The CommonJS configuration examples fail because `require()` returns a module namespace object instead of the plugin. This PR adds `.default` to access the plugin.

[Reproduce](https://stackblitz.com/edit/stackblitz-starters-fa3hqpft?file=eslint.config.cjs)

## Details

<img width="851" height="84" alt="image" src="https://github.com/user-attachments/assets/6cd92eb5-b942-41bb-b08a-431fb1c11c7b" />

I think `require('eslint-markdown')` looks cleaner but the current ESM-only export requires `.default`.

Adding `export { plugin as 'module.exports' };` to `index.ts` seems to avoid this, as shown above, though it doesn't look particularly clean either.

Is the current behavior intentional, or are there other considerations?

## How did you test this change?

Confirmed that adding `.default` fixes the error in the reproduction above.

## Resolved Issues

No issues

## Checklist

- [x] I have read the [**code of conduct**](https://github.com/lumirlumir/.github/blob/main/CODE_OF_CONDUCT.md) and **contributing guidelines** in the repository root.
